### PR TITLE
Reference instead of defining EOC in use_action

### DIFF
--- a/AnomalousThings/BookThatDontBelongToYou/Items.json
+++ b/AnomalousThings/BookThatDontBelongToYou/Items.json
@@ -11,7 +11,7 @@
     "looks_like": "story_book",
     "material": [ "flesh" ],
     "color": "red",
-    "use_action": { "type": "effect_on_conditions", "effect_on_conditions": [ { "id": "skin_book_eoc" } ] }
+    "use_action": { "type": "effect_on_conditions", "effect_on_conditions": [ "skin_book_eoc" ] }
   },
   {
     "id": "skin_prophecy_evoked",


### PR DESCRIPTION
(dda,pm_world)=>skin_book_eoc (effect_on_condition) has two definitions from the same source (pm_world)!
See DDA#74514