### PR TITLE
Added Green Dawn, reduced emotion impact and added research quotes.

### DIFF
--- a/AnomalousThings/Birdo/Research.json
+++ b/AnomalousThings/Birdo/Research.json
@@ -125,7 +125,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "beak_ego_a_1" } ] } },
     "effect": [
       { "u_spawn_item": "beak_ego_a_note_1" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "'People have been committing sins since long ago. Why do they commit sins, knowing it's wrong?' The small bird wondered.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "beak_ego_a_1", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_beak_armor" } ]
@@ -136,7 +136,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "beak_ego_a_2" } ] } },
     "effect": [
       { "u_spawn_item": "beak_ego_a_note_2" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "'It must be because there's no one to punish people for their misdeeds. If someone takes that role, then no foul act would happen in this world ever again!' With this in mind, the little bird left the forest it had been living in, and never went back.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "beak_ego_a_2", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_beak_armor" } ]
@@ -147,7 +147,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "beak_ego_a_3" } ] } },
     "effect": [
       { "u_spawn_item": "beak_ego_a_note_3" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "The Punishing Bird is a small and confident bird that punishes the evil, guilty, and all sorts of irreverent people.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "beak_ego_a_3", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_beak_armor" } ]
@@ -158,7 +158,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "beak_ego_w_1" } ] } },
     "effect": [
       { "u_spawn_item": "beak_ego_w_note_1" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "Some employees have said that it is cute when the bird mightily flutters its tiny wings.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "beak_ego_w_1", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_beak_weapon" } ]
@@ -169,7 +169,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "beak_ego_w_2" } ] } },
     "effect": [
       { "u_spawn_item": "beak_ego_w_note_2" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "A majority of the time Punishing Bird acts like any other normal bird, flying here and there in the Containment Unit.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "beak_ego_w_2", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_beak_weapon" } ]
@@ -180,7 +180,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "beak_ego_w_3" } ] } },
     "effect": [
       { "u_spawn_item": "beak_ego_w_note_3" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "Punishing Bird never cheeps or chirps. However, its stomach occasionally twitches.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "beak_ego_w_3", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_beak_weapon" } ]
@@ -191,7 +191,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "beak_ego_g_1" } ] } },
     "effect": [
       { "u_spawn_item": "beak_ego_g_note_1" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "Not many know about Punishing Bird’s disgusting flesh, which splits apart into several sections.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "beak_ego_g_1", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_beak_gift" } ]
@@ -202,7 +202,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "beak_ego_g_2" } ] } },
     "effect": [
       { "u_spawn_item": "beak_ego_g_note_2" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "It is said the Punishing Bird was never alone in the forest, and was friends with two other birds.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "beak_ego_g_2", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_beak_gift" } ]
@@ -213,7 +213,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "beak_ego_g_3" } ] } },
     "effect": [
       { "u_spawn_item": "beak_ego_g_note_3" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "There are recommendations in bold red to never let anyone who the bird has seen commit crimes into the containment unit alone.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "beak_ego_g_3", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_beak_gift" } ]

--- a/AnomalousThings/BookThatDontBelongToYou/Owner/EGO effects.json
+++ b/AnomalousThings/BookThatDontBelongToYou/Owner/EGO effects.json
@@ -79,7 +79,7 @@
       { "math": [ "u_spell_level('92_fluidity')", "=", "-1" ] },
       { "math": [ "u_spell_level('92_big_summon')", "=", "-1" ] },
       { "math": [ "u_spell_level('92_evaporize')", "=", "-1" ] },
-      { "math": [ "u_spell_level('92_live_flame_togle')", "=", "-1" ] },
+      { "math": [ "u_spell_level('92_live_flame_toggle')", "=", "-1" ] },
       { "math": [ "u_spell_level('92_gaze_hook_4')", "=", "-1" ] }
     ]
   },

--- a/AnomalousThings/BookThatDontBelongToYou/Owner/EGO spez.json
+++ b/AnomalousThings/BookThatDontBelongToYou/Owner/EGO spez.json
@@ -13,7 +13,7 @@
     "id": "EGO_92_stage_1",
     "type": "SPELL",
     "name": "[ט] EGO 9:2 stage 1 activation",
-    "description": "Activate your bond with EGO 9:2, this requires you to be in an emotional state.",
+    "description": "Activate your bond with EGO 9:2, strengthening you and wreathing you in flame.",
     "valid_targets": [ "self" ],
     "effect": "effect_on_condition",
     "effect_str": "92_stage_1_activation",
@@ -33,7 +33,7 @@
     "energy_source": "STAMINA",
     "difficulty": 3,
     "max_level": 10,
-    "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS", "EMOTION_CASTING_LOW" ]
+    "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS" ]
   },
   {
     "type": "effect_on_condition",
@@ -186,7 +186,7 @@
     "id": "EGO_92_stage_2",
     "type": "SPELL",
     "name": "[ט] EGO 9:2 stage 2 activation",
-    "description": "Your bond with EGO 9:2 has strengthened, and you may call upon it more deeply. This requires you to be in an emotional state.",
+    "description": "Your bond with EGO 9:2 has strengthened, and you may call upon it more deeply.",
     "valid_targets": [ "self" ],
     "effect": "effect_on_condition",
     "effect_str": "92_stage_2_activation",
@@ -206,7 +206,7 @@
     "energy_source": "STAMINA",
     "difficulty": 4,
     "max_level": 10,
-    "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS", "EMOTION_CASTING_LOW" ]
+    "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS" ]
   },
   {
     "type": "effect_on_condition",
@@ -474,7 +474,7 @@
     "id": "EGO_92_stage_3",
     "type": "SPELL",
     "name": "[ט] EGO 9:2 stage 3 activation",
-    "description": "Your bond with EGO 9:2 has grown deeper still, towards a vast depth of power. This requires you to be in an emotional state.",
+    "description": "Your bond with EGO 9:2 has grown deeper still, towards a vast depth of power.",
     "valid_targets": [ "self" ],
     "effect": "effect_on_condition",
     "effect_str": "92_stage_3_activation",
@@ -494,7 +494,7 @@
     "energy_source": "STAMINA",
     "difficulty": 4,
     "max_level": 10,
-    "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS", "EMOTION_CASTING_LOW" ]
+    "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS" ]
   },
   {
     "type": "effect_on_condition",
@@ -915,7 +915,7 @@
     "id": "EGO_92_stage_4",
     "type": "SPELL",
     "name": "[ט] EGO 9:2 stage 4 activation",
-    "description": "Ignites your joint flame, granting great strength and resistance to fire for a short time. Requires you to be in the throws of emotion.",
+    "description": "Ignites your joint flame, granting great strength and resistance to fire for a short time.",
     "valid_targets": [ "self" ],
     "effect": "effect_on_condition",
     "effect_str": "92_stage_4_activation",
@@ -935,7 +935,7 @@
     "energy_source": "STAMINA",
     "difficulty": 4,
     "max_level": 10,
-    "flags": [ "SILENT", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS", "EMOTION_CASTING_LOW" ]
+    "flags": [ "SILENT", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS" ]
   },
   {
     "type": "effect_on_condition",

--- a/AnomalousThings/Ordeals/Green Dawn/GreenDawnEoC.json
+++ b/AnomalousThings/Ordeals/Green Dawn/GreenDawnEoC.json
@@ -1,0 +1,61 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_green_dawn",
+    "eoc_type": "EVENT",
+    "required_event": "character_wakes_up",
+	"condition": { "and": [ { "math": ["time_since('cataclysm', 'unit':'days') >= 14"] }, { "not": { "compare_string": [ "true", { "u_val": "ordeal_lock" } ] } } ] },
+    "effect": [
+		{ "u_add_var": "ordeal_lock", "value": "true" },
+		{ "run_eocs": "EOC_green_dawn_wave" },
+		{ "run_eocs": "EOC_green_dawn_wave", "time_in_future": [ "5 minutes", "10 minutes" ] },
+		{ "run_eocs": "EOC_green_dawn_wave", "time_in_future": [ "10 minutes", "20 minutes" ] },
+		{ "run_eocs": "EOC_remove_ordeal_lock", "time_in_future": [ "14 days", "20 days" ] },
+		{ "run_eocs": "EOC_green_dawn_flavour", "time_in_future": [ "5 minutes", "10 minutes" ] },
+		{
+            "message": "<color_green>     The Dawn of Green\n\n          DOUBT\n\nTo live was a process full of pain.</color>",
+            "popup": true
+        }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_green_dawn_wave",
+    "effect": [
+		{
+            "message": "The world creaks like metal sheering away."
+        },
+		{ "u_spawn_monster": "mon_doubts", "real_count": [ { "math": [ "2 + time_since('cataclysm', 'unit':'days') / 14" ] }, { "math": [ "4 + time_since('cataclysm', 'unit':'days') / 14" ] } ], "min_radius": [ 7, 9 ], "max_radius": [ 14, 24 ] },
+		{ "run_eocs": "EOC_green_dawn_wave_repeat", "time_in_future": [ "1 minutes", "2 minutes" ] },
+		{ "run_eocs": "EOC_green_dawn_flavour", "time_in_future": [ "5 minutes", "10 minutes" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_green_dawn_wave_repeat",
+	"condition": { "x_in_y_chance": { "x": 1, "y": 10 } },
+    "effect": [
+		{
+            "message": "Reality ripples like a bubbling pot of stew."
+        },
+		{ "u_spawn_monster": "mon_doubts", "real_count": [ { "math": [ "2 + time_since('cataclysm', 'unit':'days') / 14" ] }, { "math": [ "4 + time_since('cataclysm', 'unit':'days') / 14" ] } ], "min_radius": [ 7, 9 ], "max_radius": [ 14, 24 ] },
+		{ "run_eocs": "EOC_green_dawn_wave_repeat", "time_in_future": [ "1 minutes", "2 minutes" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_remove_ordeal_lock",
+    "effect": [
+		{ "u_lose_var": "ordeal_lock" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_green_dawn_flavour",
+    "effect": [
+		{ "set_string_var": [ "Is there really any hope of surviving? Everyone dies eventually.", "TICK. TOCK. TICK. TOCK.", "The grinding of gears assaults your senses.", "This world is a clock that's already stopped.", "What about the next wound, will you survive?", "Are you just going to end up as a monster?", "You're already dead, and you know it.", "The sound of the dead is ever present.", "Just give in." ],
+          "target_var": { "u_val": "quote" } },
+		{ "message": "<u_val:quote>", "type": "mixed" }
+    ]
+  }
+]

--- a/AnomalousThings/Ordeals/Green Dawn/RobotSpecial.json
+++ b/AnomalousThings/Ordeals/Green Dawn/RobotSpecial.json
@@ -1,0 +1,129 @@
+[
+  {
+    "id": "spell_robot_impale",
+    "type": "SPELL",
+    "name": "Impale",
+    "description": "Stabbed by a lance.",
+    "valid_targets": [ "hostile" ],
+	"flags": [ "RANDOM_DAMAGE", "NO_LEGS", "NO_EXPLOSION_SFX", "RANDOM_DURATION" ],
+    "effect": "attack",
+	"effect_str": "downed",
+    "shape": "blast",
+    "damage_type": "stab",
+    "min_damage": 5,
+    "max_damage": 30,
+    "damage_increment": 2,
+    "min_range": 1,
+    "max_range": 1,
+	"min_duration": 100,
+	"max_duration": 500,
+    "difficulty": 1,
+    "max_level": 10,
+	"base_casting_time": 75,
+    "final_casting_time": 30,
+    "casting_time_increment": -3,
+    "message": "The Doubt slams it's lance into you.",
+    "sound_type": "combat",
+	"extra_effects": [
+	  {
+	    "id": "spell_robot_impale_if_downed"
+      }
+    ]	
+  },
+  {
+    "id": "spell_robot_impale_if_downed",
+    "type": "SPELL",
+    "name": "Impale check.",
+    "description": "Checks if opponent is downed.",
+    "valid_targets": [ "hostile" ],
+	"flags": [ "NO_LEGS", "NO_EXPLOSION_SFX" ],
+    "effect": "effect_on_condition",
+    "effect_str": "robot_hook",
+    "shape": "blast",
+    "max_level": 5,
+    "message": "Swoosh"
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "robot_hook",
+	"condition": {  "u_has_effect": "downed"  },
+    "effect": [
+      { "message": "The Doubt takes advantage of having knocked you over, slamming its bloody lance into you again and again and again..", "type": "bad" }, 
+	  { "u_cast_spell": { "id": "spell_robot_overkill", "hit_self": true } }
+    ]
+  },
+  {
+    "id": "spell_robot_overkill",
+    "type": "SPELL",
+    "name": "Impale",
+    "description": "Repeated stabbing of a downed enemy by a lance.",
+    "valid_targets": [ "hostile", "self" ],
+	"flags": [ "WONDER", "NO_LEGS", "NO_EXPLOSION_SFX" ],
+    "effect": "attack",
+    "shape": "blast",
+    "damage_type": "stab",
+    "min_damage": 5,
+    "max_damage": 15,
+    "damage_increment": 5,
+    "min_range": 1,
+    "max_range": 1,
+    "max_level": 5,
+	"extra_effects": [
+	  {
+	    "id": "spell_robot_overkill_true"
+      }
+	]
+  },
+  {
+    "id": "spell_robot_overkill_true",
+    "type": "SPELL",
+    "name": "Impale",
+    "description": "Repeated stabbing of a downed enemy by a lance.",
+    "valid_targets": [ "hostile", "self" ],
+	"flags": [ "RANDOM_DAMAGE", "NO_LEGS", "NO_EXPLOSION_SFX" ],
+    "effect": "attack",
+    "shape": "blast",
+    "damage_type": "stab",
+    "min_damage": 10,
+    "max_damage": 20,
+    "damage_increment": 5,
+    "min_range": 1,
+    "max_range": 1,
+    "difficulty": 1,
+    "max_level": 5,
+    "message": "STAB!!",
+    "sound_type": "combat",
+	"min_pierce": 10,           
+    "max_pierce": 20,
+	"extra_effects": [
+	  {
+	    "id": "spell_robot_overkill_morale"
+      }
+	]
+  },
+  {
+    "id": "spell_robot_overkill_morale",
+    "type": "SPELL",
+    "name": "Initiates the morale check.",
+    "description": "Checks if opponent is downed.",
+    "valid_targets": [ "hostile" ],
+	"flags": [ "NO_LEGS", "NO_EXPLOSION_SFX" ],
+    "effect": "effect_on_condition",
+    "effect_str": "robot_hook_morale",
+    "shape": "blast",
+    "max_level": 5
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "robot_hook_morale",
+    "effect": [
+      {
+        "u_add_morale": "impaled_morale",
+        "bonus": -10,
+        "max_bonus": -500,
+        "duration": "30 minutes",
+        "decay_start": "10 minutes"
+      }
+    ]
+  }
+]

--- a/AnomalousThings/Ordeals/Green Dawn/RustyRobots.json
+++ b/AnomalousThings/Ordeals/Green Dawn/RustyRobots.json
@@ -1,0 +1,40 @@
+[
+    {
+        "id": "mon_doubts",
+        "type": "MONSTER",
+        "name": { "str": "<color_green>Doubt</color>" },
+        "description": "A creature made of dark metal and gears that buzz with a constant movement. Several red 'eyes' gleam out of it's faceplate, dead set on you, always on you. Each clack of movement a threat, and nothing says that more than the lance that takes the place of its only hand, gleaming with what appears to be fresh blood.",
+        "default_faction": "distortions",
+        "bodytype": "human",
+        "species": [ "DISTORTIONS" ],
+        "volume": "65 L",
+        "weight": "126 kg",
+        "hp": 348,
+        "speed": 60,
+        "material": [ "steel" ],
+        "looks_like": "mon_zombie_fireman",
+        "symbol": "D",
+        "color": "black",
+        "aggression": 100,
+        "morale": 100,
+        "aggro_character": true,
+        "melee_skill": 3,
+        "melee_dice": 1,
+        "melee_dice_sides": 8,
+        "melee_damage": [ { "damage_type": "stab", "amount": 6 } ],
+        "special_attacks": [ 
+			{ "id": "robot_impale", "type": "spell", "spell_data": { "id": "spell_robot_impale", "min_level": 1 }, "cooldown": 5, "monster_message": "The Doubt slams it's lance into you." } 
+			],
+        "dodge": 0,
+        "grab_strength": 4,
+        "weakpoint_sets": [ "wps_humanoid_body" ],
+        "families": [ "prof_wp_distortions0", "prof_wp_distortions1" ],
+        "vision_day": 55,
+        "vision_night": 55,
+        "harvest": "mutant_human",
+        "flags": [ "SEES", "HEARS", "PATH_AVOID_FALL", "ALWAYS_SEES_YOU", "BASHES",
+                    "GRABS", "SWIMS", "PUSH_MON", "GROUP_BASH" ],
+        "armor": { "electric": -3, "heat": 20, "bash": -2, "cut": 8, "stab": 8, "bullet": 5, "acid":10 },
+		"death_drops": [ { "item": "rustedgear_item", "prob": 20 }, { "item": "rustedlance_item", "prob": 4 } ]
+      }
+]

--- a/AnomalousThings/Ordeals/Green Dawn/RustyRobotsItems.json
+++ b/AnomalousThings/Ordeals/Green Dawn/RustyRobotsItems.json
@@ -1,0 +1,40 @@
+[
+  {
+    "id": "rustedgear_item",
+    "type": "GENERIC",
+    "name": { "str": "rusted gear", "str_pl": "rusted gears" },
+    "description": "A rusted gear, though its hard to tell what metal its made from, lightweight and dark yet with a strength that's not easily moulded.",
+    "volume": "1 ml",
+    "weight": "1 g",
+    "longest_side": "16 cm",
+    "price_postapoc": 1500,
+    "to_hit": { "balance": "neutral", "grip": "bad", "length": "hand", "surface": "any" },
+    "melee_damage": { "bash": 1 },
+    "material": [ "l_steel" ],
+    "symbol": "g",
+    "looks_like": "steel",
+    "color": "black"
+  },
+  {
+    "id": "rustedlance_item",
+    "name": { "str": "rusted lance"},
+    "description": "A horribly rusted lance, not made to be held by human hands. There is an obvious bump near its haft where it used to be wielded by it's original owner, who has long since rusted away.",
+    "color": "black",
+	"type": "TOOL",
+    "category": "weapons",
+    "weight": "4216 g",
+    "volume": "5250 ml",
+    "longest_side": "217 cm",
+    "symbol": "/",
+    "looks_like": "spear",
+    "price": 120000,
+    "price_postapoc": 11900,
+    "material": [ { "type": "b_steel", "portion": 160 } ],
+    "repairs_with": [ "b_steel_item" ],
+    "flags": [ "SPEAR", "ALWAYS_TWOHAND", "DURABLE_MELEE", "REACH_ATTACK", "SLOW_WIELD" ],
+    "techniques": [ "WBLOCK_1", "DEF_DISARM", "BRUTAL" ],
+    "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "good" },
+    "weapon_category": [ "POLEARMS", "SPEARS" ],
+    "melee_damage": { "bash": 4, "stab": 24 }
+  }
+]

--- a/AnomalousThings/Ordeals/Green Dawn/RustyRobotsMorale.json
+++ b/AnomalousThings/Ordeals/Green Dawn/RustyRobotsMorale.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "impaled_morale",
+    "type": "morale_type",
+    "text": "Such horrendous bloodshed! Such agony!"
+  }
+]

--- a/AnomalousThings/Wellcheers/Research.json
+++ b/AnomalousThings/Wellcheers/Research.json
@@ -130,7 +130,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "soda_ego_a_1" } ] } },
     "effect": [
       { "u_spawn_item": "soda_ego_a_note_1" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "No-one really knows where these cans come from, although a vending machine has been found, it has never been restocked and yet never ran dry.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "soda_ego_a_1", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_soda_armor" } ]
@@ -141,7 +141,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "soda_ego_a_2" } ] } },
     "effect": [
       { "u_spawn_item": "soda_ego_a_note_2" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "It has been said the drinks are sometimes laced with sleeping pills, though that's an odd rumour.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "soda_ego_a_2", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_soda_armor" } ]
@@ -152,7 +152,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "soda_ego_a_3" } ] } },
     "effect": [
       { "u_spawn_item": "soda_ego_a_note_3" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "Falling asleep after drinking Wellcheers is a sign of horrendous luck.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "soda_ego_a_3", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_soda_armor" } ]
@@ -163,7 +163,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "soda_ego_w_1" } ] } },
     "effect": [
       { "u_spawn_item": "soda_ego_w_note_1" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "The mascot for the drink is an offputtingly anthropomorphic shrimp that looks more like it wants to stab you than help.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "soda_ego_w_1", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_soda_weapon" } ]
@@ -174,7 +174,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "soda_ego_w_2" } ] } },
     "effect": [
       { "u_spawn_item": "soda_ego_w_note_2" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "Despite being what appears to be a processed drink, Wellcheers is surprisingly good for your health.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "soda_ego_w_2", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_soda_weapon" } ]
@@ -185,7 +185,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "soda_ego_w_3" } ] } },
     "effect": [
       { "u_spawn_item": "soda_ego_w_note_3" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "There are a number of cases within the Anomalies document that mention staff going missing after drinking Wellcheers and falling asleep.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "soda_ego_w_3", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_soda_weapon" } ]
@@ -196,7 +196,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "soda_ego_g_1" } ] } },
     "effect": [
       { "u_spawn_item": "soda_ego_g_note_1" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "Though the Cherry and normal varients of Wellcheers are good, staff reported feeling far more refreshed with the Grape flavour.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "soda_ego_g_1", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_soda_gift" } ]
@@ -207,7 +207,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "soda_ego_g_2" } ] } },
     "effect": [
       { "u_spawn_item": "soda_ego_g_note_2" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "There is allegedly a fourth flavour of Wellcheers, shrimp, said to be the best by far, and yet this flavour has never been found or dispensed.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "soda_ego_g_2", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_soda_gift" } ]
@@ -218,7 +218,7 @@
     "condition": { "not": { "compare_string": [ "true", { "u_val": "soda_ego_g_3" } ] } },
     "effect": [
       { "u_spawn_item": "soda_ego_g_note_3" },
-      { "message": "<color_green>Success!</color>", "popup": true },
+      { "message": "Strangely, despite it's anomalous status, Wellcheers had an advert marking it as publically available.\n\n<color_green>Success!</color>", "popup": true },
       { "u_add_var": "soda_ego_g_3", "value": "true" }
     ],
     "false_effect": [ { "run_eocs": "EOC_on_activity_complete_soda_gift" } ]

--- a/Npc/TheirChores/ZweiMission.json
+++ b/Npc/TheirChores/ZweiMission.json
@@ -45,7 +45,7 @@
           { "group": "PECCA_GENERAL", "x": [ 1, 18 ], "y": [ 1, 18 ], "repeat": [ 2, 7 ] },
           { "group": "GROUP_ZOMBIE_UPGRADE", "x": [ 1, 18 ], "y": [ 1, 18 ], "repeat": [ 15, 48 ] }
         ],
-        "om_terrain": "s_bookstore",
+
         "place_item": [ { "item": "ZSG", "x": 3, "y": 10 } ]
       }
     },

--- a/Npc/TheirVoices/Rusted Chains/Duglas.json
+++ b/Npc/TheirVoices/Rusted Chains/Duglas.json
@@ -41,11 +41,19 @@
 },
 {
     "type" :"talk_topic",
+    "id" : "ACCEPT_MISSION_DUGLAS",
+    "dynamic_line" : "[Quest Currently unimplemented] You better come back with good news, or don't bother showing your face again.",
+    "responses" :[
+        {"text" : "Alright, alright, I'm leaving", "topic" : "TALK_DONE"}
+    ]
+},
+{
+    "type" :"talk_topic",
     "id" : "EVENT_FIGHT_DUGLAS",
     "dynamic_line" : "Then why the hell are you bothering me? Get out of here!",
     "responses" :[
         {"text" : "Calm down. Why are you so nervous?", "topic" : "FIGHT_DUGLAS"},
-        {"text" : "Alright, i'm leaving", "topic" : "TALK_DONE"}
+        {"text" : "Alright, I'm leaving", "topic" : "TALK_DONE"}
     ]
 }
 ]

--- a/emotion.json
+++ b/emotion.json
@@ -56,15 +56,6 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "emotion_characterfinishedactivity",
-    "eoc_type": "EVENT",
-    "required_event": "character_finished_activity",
-	"effect": [
-	  { "math": [ "u_vitamin('emotion') += 2" ] } 
-	  ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "emotion_charactermeleeattacksmonster",
     "eoc_type": "EVENT",
     "required_event": "character_melee_attacks_monster",
@@ -105,7 +96,7 @@
     "eoc_type": "EVENT",
     "required_event": "character_takes_damage",
 	"effect": [
-	  { "math": [ "u_vitamin('emotion') += 8" ] }
+	  { "math": [ "u_vitamin('emotion') += 4" ] }
     ]
   }
   


### PR DESCRIPTION
Fixes:
- Made emotion not raise after every action
- Reduced some gaining of emotion
- Fixed the Zombie Survival Guide not spawning in the Zwei quest
- Rusted Chain quest no longer crashes and has placeholder text

Additions:
- Flavour text added for completing research, lore accurate for the most part, we know little about wellcheers
- Green Dawn added, will occur on the 14th day when you wake, will reoccur roughly fortnightly
- Doubts have been added, they have a cruel attack if you are knocked down by their first
- Green Dawn gets marginally worse the longer you have played, spawning more Doubts
- Doubt spawning is slightly randomised, some Green Dawns can be worse than others
- Added a misc gear drop to Doubts for later implementation, as well as a usable lance