### PR TITLE
Added harvesting, basic Enk with recipies, polished Soda

### DIFF
--- a/AnomalousThings/Ordeals/Green Dawn/RustyRobots.json
+++ b/AnomalousThings/Ordeals/Green Dawn/RustyRobots.json
@@ -37,7 +37,7 @@
     "families": [ "prof_wp_distortions0", "prof_wp_distortions1" ],
     "vision_day": 55,
     "vision_night": 55,
-    "harvest": "mutant_human",
+    "death_function": { "corpse_type": "BROKEN" },
     "flags": [ "SEES", "HEARS", "PATH_AVOID_FALL", "ALWAYS_SEES_YOU", "BASHES", "GRABS", "SWIMS", "PUSH_MON", "GROUP_BASH" ],
     "armor": { "electric": -5, "heat": 20, "bash": -6, "cut": 11, "stab": 14, "bullet": 20, "acid": 10 },
     "death_drops": [ { "item": "rustedgear_item", "prob": 20 }, { "item": "rustedlance_item", "prob": 4 } ]

--- a/AnomalousThings/Ordeals/Green Dawn/RustyRobotsItems.json
+++ b/AnomalousThings/Ordeals/Green Dawn/RustyRobotsItems.json
@@ -1,5 +1,21 @@
 [
   {
+    "type": "GENERIC",
+    "id": "broken_doubts",
+    "symbol": ",",
+    "color": "green",
+    "name": { "str": "broken doubt" },
+    "category": "other",
+    "description": "The doubt no longer looks as intimidating, now that it's metallic body and organs have been sheered.",
+    "price": "10 USD",
+    "material": [ "steel" ],
+    "weight": "126 kg",
+    "volume": "65 L",
+    "to_hit": -3,
+    "flags": [ "TRADER_AVOID", "NO_REPAIR" ],
+    "melee_damage": { "bash": 6, "cut": 6 }
+  },
+  {
     "id": "rustedgear_item",
     "type": "GENERIC",
     "name": { "str": "rusted gear", "str_pl": "rusted gears" },

--- a/AnomalousThings/Ordeals/Green Dawn/RustyRobotsRecipies.json
+++ b/AnomalousThings/Ordeals/Green Dawn/RustyRobotsRecipies.json
@@ -1,0 +1,17 @@
+[
+  {
+    "result": "broken_doubts",
+    "type": "uncraft",
+    "activity_level": "BRISK_EXERCISE",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "time": "12 m",
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WELD", "level": 1 } ],
+    "components": [
+      [ [ "rustedgear_item", 4 ] ],
+      [ [ "casepiece_item", 1 ] ],
+      [ [ "lc_wire", 8 ] ],
+      [ [ "qt_steel_lump", 2 ] ]
+    ]
+  }
+]

--- a/AnomalousThings/Wellcheers/Soda/EGO Soda.json
+++ b/AnomalousThings/Wellcheers/Soda/EGO Soda.json
@@ -13,7 +13,7 @@
     "id": "EGO_soda_stage_1",
     "type": "SPELL",
     "name": "[ז] EGO Soda stage 1 activation",
-    "description": "Activate your bond with Soda, strengthening you and granting you the ability to give enemies the slip.",
+    "description": "Activate your bond with Soda, strengthening you and granting you the ability to give enemies the slip. However, any contact with an EGO takes a toll.",
     "valid_targets": [ "self" ],
     "effect": "effect_on_condition",
     "effect_str": "soda_stage_1_activation",
@@ -70,7 +70,7 @@
   {
     "id": "EGO_soda_stage_1_success",
     "type": "SPELL",
-    "name": "[ז] EGO Soda stage 1 activation",
+    "name": "[ז] EGO Soda Invoke Bond - Stage 1",
     "description": "",
     "valid_targets": [ "self" ],
     "effect": "spawn_item",
@@ -95,7 +95,7 @@
     "id": "EGO_soda_stage_1_aura",
     "type": "ARMOR",
     "name": "[ז] EGO Soda Pale Aura",
-    "description": "desc",
+    "description": "You feel Soda's presence in your mind, alien, twisting and writhing, yet granting you power beyond any mere mortal. While the bond is active you sense you'll be slightly harder to knock down, better at dodging, and find it easier to throw items.",
     "weight": "0 g",
     "volume": "0 ml",
     "material": [ "wind" ],
@@ -130,8 +130,8 @@
   {
     "id": "EGO_soda_stage_2",
     "type": "SPELL",
-    "name": "[ז] EGO Soda stage 2 activation",
-    "description": "Your bond with Soda has strengthened, and you may call upon it more deeply.",
+    "name": "[ז] EGO Soda Invoke Bond - Stage 2",
+    "description": "Your bond with Soda has strengthened, and you may call upon it more deeply. However, any contact with an EGO takes a toll.",
     "valid_targets": [ "self" ],
     "effect": "effect_on_condition",
     "effect_str": "soda_stage_2_activation",
@@ -242,7 +242,7 @@
     "id": "EGO_soda_stage_2_aura",
     "type": "ARMOR",
     "name": "[ז] EGO Soda Insubstantial Aura",
-    "description": "A formless aura emanates from you.",
+    "description": "You feel Soda's now familiar aura encase you, it's words more understandable, and sharing your mind less jarring. While the bond is active you sense you'll be harder to knock down, better at dodging, and find it easier to throw items.",
     "weight": "0 g",
     "volume": "0 ml",
     "material": [ "wind" ],
@@ -388,8 +388,8 @@
   {
     "id": "EGO_soda_stage_3",
     "type": "SPELL",
-    "name": "[ז] EGO Soda stage 3 activation",
-    "description": "Your bond with Soda has grown deeper still, towards a vast depth of power.",
+    "name": "[ז] EGO Soda Invoke Bond - Stage 3",
+    "description": "Your bond with Soda has grown deeper still, towards a vast depth of power. Call upon it, however, any contact with an EGO takes a toll.",
     "valid_targets": [ "self" ],
     "effect": "effect_on_condition",
     "effect_str": "soda_stage_3_activation",
@@ -501,7 +501,7 @@
     "id": "EGO_soda_stage_3_aura",
     "type": "ARMOR",
     "name": "[ז] EGO Soda Vivid Aura",
-    "description": "A strong aura emanates from you, colours manifest even in dim light.",
+    "description": "You feel Soda moving alongside you, a familiar friend now, even as they share your own skin, manifesting arms and armour at your call. While the bond is active you sense you'll be much harder to knock down, better at dodging, and find it easier to throw items.",
     "weight": "0 g",
     "volume": "0 ml",
     "material": [ "wind" ],
@@ -532,7 +532,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "spells_learned": [ [ "soda_can_normal_hook", 1 ], [ "soda_armor_normal_hook", 1 ], [ "soda_net_empower_hook", 1 ] ]
+    "spells_learned": [ [ "soda_can_normal_hook", 1 ], [ "soda_armor_normal_hook", 1 ], [ "soda_net_empower_hook", 1 ], [ "soda_summon_wellcheers_hook", 1 ] ]
   },
   {
     "id": "soda_can_normal_hook",
@@ -784,7 +784,7 @@
     "id": "soda_armor_normal_item",
     "type": "ARMOR",
     "name": { "str": "<color_red>EGO Armor of Soda</color>" },
-    "description": "The waxy fabric of a dredger's overcoat and yet somehow stronger despite the thickness. something about it feels off whenever you look at it for too long, almost as if the waxiness is biological, moving, and shifting to better protect the wearer.",
+    "description": "The waxy fabric of a shrimper's overcoat and yet somehow stronger despite the thickness. something about it feels off whenever you look at it for too long, almost as if the waxiness is biological, moving, and shifting to better protect the wearer.",
     "weight": "3842 g",
     "volume": "500 ml",
     "price": "0 cent",
@@ -807,8 +807,8 @@
   {
     "id": "EGO_soda_stage_4",
     "type": "SPELL",
-    "name": "[ז] EGO Soda stage 4 activation",
-    "description": "Ignites your joint flame, granting great strength and resistance to fire for a short time.",
+    "name": "[ז] EGO Soda Invoke Bond - Stage 4",
+    "description": "Call your bond with Soda from the unfathomable depth of your entangling bond. However, any contact with an EGO takes a toll.",
     "valid_targets": [ "self" ],
     "effect": "effect_on_condition",
     "effect_str": "soda_stage_4_activation",
@@ -935,7 +935,7 @@
     "id": "EGO_soda_stage_4_aura",
     "type": "ARMOR",
     "name": "[ז] EGO Soda Awakened Aura",
-    "description": "A strong aura emanates from you, a myriad of colours manifest even in dim light.",
+    "description": "You feel Soda's presence in your mind, alien, now that of a partner, you both act in a perfect synergy towards your aims. While the bond is active you sense you'll be significantly harder to knock down, better at dodging, and find it easier to throw items.",
     "weight": "0 g",
     "volume": "0 ml",
     "material": [ "wind" ],
@@ -967,7 +967,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "spells_learned": [ [ "soda_can_empower_hook", 1 ], [ "soda_armor_empower_hook", 1 ], [ "soda_net_empower_hook", 1 ] ]
+    "spells_learned": [ [ "soda_can_empower_hook", 1 ], [ "soda_armor_empower_hook", 1 ], [ "soda_net_empower_hook", 1 ], [ "soda_summon_wellcheers_hook", 1 ] ]
   },
   {
     "id": "soda_can_empower_hook",
@@ -1220,7 +1220,7 @@
     "id": "soda_armor_empowered_item",
     "type": "ARMOR",
     "name": { "str": "<color_red>EGO Armor of Soda</color>" },
-    "description": "The waxy fabric of a dredger's overcoat and yet somehow stronger despite the thickness. something about it feels off whenever you look at it for too long, almost as if the waxiness is biological, moving, and shifting to better protect the wearer.",
+    "description": "The waxy fabric of a shrimper's overcoat and yet somehow stronger despite the thickness. something about it feels off whenever you look at it for too long, almost as if the waxiness is biological, moving, and shifting to better protect the wearer.",
     "weight": "3842 g",
     "volume": "500 ml",
     "price": "0 cent",
@@ -1239,6 +1239,68 @@
         "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
       }
     ]
+  },
+  {
+    "id": "soda_summon_wellcheers_hook",
+    "type": "SPELL",
+    "name": "[ז] EGO Soda - Summon Can of WellCheers",
+    "description": "Manifest an actual can of WellCheers that doesn't, you know, explode. It is ephemeral however, and will not last long if not consumed. Manifesting such a thing from the aether is very taxing in the long term.",
+    "valid_targets": [ "self" ],
+    "effect": "effect_on_condition",
+    "effect_str": "soda_summon_wellcheers_eoc",
+    "shape": "blast",
+    "min_range": 0,
+    "max_range": 0,
+    "min_aoe": 0,
+    "max_aoe": 0,
+    "min_duration": 20000,
+    "max_duration": 20000,
+    "base_casting_time": 200,
+    "final_casting_time": 200,
+    "spell_class": "EGO_Soda",
+    "base_energy_cost": 250,
+    "final_energy_cost": 250,
+    "energy_source": "STAMINA",
+    "difficulty": 4,
+    "max_level": 1,
+    "flags": [ "SILENT", "NO_LEGS", "NO_ARMS" ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "soda_summon_wellcheers_eoc",
+    "effect": [
+	  { "u_cast_spell": { "id": "soda_summon_wellcheers_true", "min_level": 1 } },
+	  { "math": [ "u_health() -= 5" ] },
+      {
+        "message": "A delightfully refreshing beverage materialises into your hand. You feel.. A little more weary from the effort.",
+        "type": "good"
+      }
+    ]
+  },
+  {
+    "id": "soda_summon_wellcheers_true",
+    "type": "SPELL",
+    "name": "[ז] EGO Soda - Summon Can of WellCheers",
+    "description": "Manifest an actual can of WellCheers that doesn't, you know, explode. It is ephemeral however, and will not last long if not consumed. Manifesting such a thing from the aether is very taxing in the long term.",
+    "valid_targets": [ "self" ],
+    "effect": "spawn_item",
+    "effect_str": "wellcheers",
+    "shape": "blast",
+    "min_range": 0,
+    "max_range": 0,
+    "min_aoe": 0,
+    "max_aoe": 0,
+    "min_duration": 1000,
+    "max_duration": 1000,
+    "base_casting_time": 200,
+    "final_casting_time": 200,
+    "spell_class": "EGO_Soda",
+    "base_energy_cost": 250,
+    "final_energy_cost": 250,
+    "energy_source": "STAMINA",
+    "difficulty": 0,
+    "max_level": 1,
+    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "NO_ARMS" ]
   },
   {
     "type": "effect_on_condition",

--- a/Items/body_parts.json
+++ b/Items/body_parts.json
@@ -1,0 +1,76 @@
+[
+  {
+    "type": "COMESTIBLE",
+    "comestible_type": "FOOD",
+    "id": "tainted_distortion_organ",
+    "name": {
+      "str": "distorted organ"
+    },
+    "material": [
+      "hflesh"
+    ],
+    "symbol": "%",
+    "color": "red",
+    "parasites": 32,
+    "vitamins": [
+      [
+        "meat_allergen",
+        1
+      ],
+      [
+        "human_flesh_vitamin",
+        1
+      ]
+    ],
+    "flags": [
+      "RAW",
+      "ACID",
+      "HIDDEN_HALLU"
+    ],
+    "description": "An odd organ found within a distortion. It's almost silky to the touch, but leaks an odd fluid.",
+    "weight": "72 g",
+    "volume": "250 ml",
+    "price_postapoc": "20 USD",
+    "spoils_in": "128 hours",
+    "calories": 120,
+    "quench": 1,
+    "fun": -100
+  },
+  {
+    "type": "COMESTIBLE",
+    "comestible_type": "FOOD",
+    "id": "corrupted_distortion_organ",
+    "name": {
+      "str": "corrupted organ"
+    },
+    "material": [
+      "hflesh"
+    ],
+    "symbol": "%",
+    "color": "red",
+    "parasites": 32,
+    "vitamins": [
+      [
+        "meat_allergen",
+        1
+      ],
+      [
+        "human_flesh_vitamin",
+        1
+      ]
+    ],
+    "flags": [
+      "RAW",
+      "ACID",
+      "HIDDEN_HALLU"
+    ],
+    "description": "An odd organ found within a distortion, this one seems oddly alive despite having been removed.",
+    "weight": "72 g",
+    "volume": "250 ml",
+    "price_postapoc": "160 USD",
+    "spoils_in": "128 hours",
+    "calories": 120,
+    "quench": 1,
+    "fun": -100
+  }
+]

--- a/Items/books_and_journals.json
+++ b/Items/books_and_journals.json
@@ -1,0 +1,73 @@
+[
+  {
+    "type": "BOOK",
+    "id": "resjournal",
+    "category": "manuals",
+    "symbol": ",",
+    "color": "white",
+    "name": {
+      "str": "researcher's journal"
+    },
+    "description": "A small journal.  Something's written in it, scrawled in bad handwriting.",
+    "price": "0 cent",
+    "price_postapoc": "5 USD",
+    "material": [
+      "paper"
+    ],
+    "flags": [
+      "TRADER_AVOID"
+    ],
+    "weight": "108 mg",
+    "volume": "16 ml",
+    "required_level": 1,
+    "max_level": 2,
+    "intelligence": 7,
+    "time": "10 m"
+  },
+  {
+    "type": "GENERIC",
+    "id": "resjournalrisk",
+    "name": {
+      "str": "researcher's journal"
+    },
+    "description": "A well used journal in a battered leather binding, detailing the risk levels assigned to Abnormalities and Distortions.\n\n\"...ZAYIN is the lowest risk level assigned to Abnormalities and Distortions, this does not mean they aren't dangerous in their own right, but a well prepared human can often deal with such a threat and face no great issues. Any abilities displayed by those assigned ZAYIN tend to be minor, easily avoided, or beneficial in effect. TETH is a noticable step beyond that, and each should be treated with caution even if they appear benevolent. These should stay under armed guard. HE, then, are terrifying beings and we never recommend handling them alone or unprepared. I've never had the pleasure of meeting a WAW abnormality and can only speculate...\"",
+    "copy-from": "resjournal"
+  },
+  {
+    "type": "GENERIC",
+    "id": "resjournalego",
+    "name": {
+      "str": "researcher's journal"
+    },
+    "description": "A well used journal in a battered leather binding, detailing what are denoted as EGOs.\n\n\"...There is a common misunderstanding as to what makes an EGO, this is in part the fault of Lobotomy Corp, whose research denoted their cheap knockoffs as EGO equipment, and while similar, they are a different strain. Lob Corp's Egos were created from Abnormalities, manufactured and though contain some of the Abnormalities power, that is all. There is nothing deeper. They are still incredible items, transferring knowledge of the item's use, even to the untaught, and deadly beyond measure, but still, different. EGOs, real ones, are made by forming a connection with an Abnormality. These kind of EGOs are weak at first, but evolve as the user grows more syncronous with the Abnormality. They are, however, dangerous, as using them allows the Abnormalities Ego to try and override your own, the weak willed eventually Distorting. The final type of EGO is that of anyone who manifests the light...\"",
+    "copy-from": "resjournal"
+  },
+  {
+    "type": "GENERIC",
+    "id": "resjournaldistortion",
+    "name": {
+      "str": "researcher's journal"
+    },
+    "description": "A well used journal in a battered leather binding, detailing what are denoted as distortions.\n\n\"\"",
+    "copy-from": "resjournal"
+  },
+  {
+    "type": "GENERIC",
+    "id": "resjournalabnormality",
+    "name": {
+      "str": "researcher's journal"
+    },
+    "description": "A well used journal in a battered leather binding, detailing what are denoted as abnormalities.\n\n\"\"",
+    "copy-from": "resjournal"
+  },
+  {
+    "type": "BOOK",
+    "category": "manuals",
+    "id": "resjournalenk",
+    "name": {
+      "str": "researcher's journal"
+    },
+    "description": "A well used journal in a battered leather binding, detailing some chemical known as Enkephalin.\n\n\"\"",
+    "copy-from": "resjournal"
+  }
+]

--- a/Items/enkephalin.json
+++ b/Items/enkephalin.json
@@ -1,0 +1,116 @@
+[
+  {
+    "type": "COMESTIBLE",
+    "id": "tainted_enk",
+    "name": {
+      "str_sp": "Tainted Enkephalin"
+    },
+    "category": "chems",
+    "weight": "5 g",
+    "color": "green",
+    "container": "enk_capsule",
+    "sealed": true,
+    "symbol": "~",
+    "description": "An odd light blue liquid that shimmers with a green light, something feels very, very wrong with it. The longer you look, the more you feel something crawl in the back of your head. It doesn't belong.",
+    "price_postapoc": 4000,
+    "volume": "25 ml",
+    "phase": "liquid",
+    "flags": [
+    ],
+    "comestible_type": "INVALID",
+	"charges": 5
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "corrupted_enk",
+    "name": {
+      "str_sp": "Corrupted Enkephalin"
+    },
+    "category": "chems",
+    "weight": "1 g",
+    "color": "black",
+    "container": "enk_capsule",
+    "sealed": true,
+    "symbol": "~",
+    "description": "Even before you make it out, this liquid screams of wrongness, as it drips it evokes sounds of a thousand legs, chattering away. Skin peels and the world ruptures, this drips like blood. Even it's colour is impossible to determine, slipping away like sand.",
+    "price_postapoc": 400000,
+    "volume": "5 ml",
+    "phase": "liquid",
+    "flags": [
+    ],
+    "comestible_type": "INVALID",
+	"charges": 5
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "enk",
+    "name": {
+      "str_sp": "Enkephalin"
+    },
+    "category": "chems",
+    "weight": "5 g",
+    "color": "light_green",
+    "container": "enk_capsule",
+    "sealed": true,
+    "symbol": "~",
+    "description": "This liquid has an almost greenish tinge, just looking at it makes your head start to grow fuzzy, probably best not to stare.",
+    "price_postapoc": 8000,
+    "volume": "25 ml",
+    "phase": "liquid",
+    "flags": [
+    ],
+    "comestible_type": "INVALID",
+	"charges": 5
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "pure_enk",
+    "name": {
+      "str_sp": "Pure Enkephalin"
+    },
+    "category": "chems",
+    "weight": "1 g",
+    "color": "light_green",
+    "container": "enk_capsule",
+    "sealed": true,
+    "symbol": "~",
+    "description": "It's impossible to determine anything about this liquid, even looking at it causes hallucinations, some of which almost seem too real. More real than anyone. Anything.",
+    "price_postapoc": 800000,
+    "volume": "2 ml",
+    "phase": "liquid",
+    "flags": [
+    ],
+    "comestible_type": "INVALID",
+	"charges": 5
+  },
+  {
+    "id": "enk_capsule",
+    "type": "GENERIC",
+    "category": "container",
+    "name": { "str": "Enkephalin Capsule" },
+    "description": "A container that appears almost overengineered at first glance, made of a lightweight black alloy, with a glass panel to see what has been stored inside. The top can be opened with a latch, though remains secure even through rigorous bumps.",
+    "looks_like": "can_drink",
+    "weight": "12 g",
+    "volume": "350 ml",
+    "price": 0,
+    "price_postapoc": 0,
+    "to_hit": -3,
+    "material": [ "b_steel" ],
+    "symbol": ")",
+    "color": "light_red",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": true,
+        "watertight": true,
+        "open_container": true,
+        "max_contains_volume": "250 ml",
+        "max_item_volume": "10 ml",
+        "max_contains_weight": "1 kg",
+        "sealed_data": { "spoil_multiplier": 0.0 }
+      }
+    ],
+    "flags": [ "COLLAPSE_CONTENTS" ],
+    "melee_damage": { "bash": 4 }
+  }
+]

--- a/Items/harvest.json
+++ b/Items/harvest.json
@@ -1,0 +1,67 @@
+[
+  {
+    "id": "distortion_zayin",
+    "type": "harvest",
+    "message": "",
+    "entries": [
+      { "drop": "tainted_distortion_organ", "type": "flesh", "mass_ratio": 0.0001 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "blood", "type": "blood", "mass_ratio": 0.1 },
+      { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.33 },
+      { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.1 },
+      { "drop": "bone_human", "type": "flesh", "mass_ratio": 0.1 }
+    ]
+  },
+  {
+    "id": "distortion_teth",
+    "type": "harvest",
+    "message": "",
+    "entries": [
+      { "drop": "tainted_distortion_organ", "type": "flesh", "mass_ratio": 0.0002 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "blood", "type": "blood", "mass_ratio": 0.1 },
+      { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.33 },
+      { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.1 },
+      { "drop": "bone_human", "type": "flesh", "mass_ratio": 0.1 }
+    ]
+  },
+  {
+    "id": "distortion_he",
+    "type": "harvest",
+    "message": "",
+    "entries": [
+      { "drop": "tainted_distortion_organ", "type": "flesh", "mass_ratio": 0.0004 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "blood", "type": "blood", "mass_ratio": 0.1 },
+      { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.33 },
+      { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.1 },
+      { "drop": "bone_human", "type": "flesh", "mass_ratio": 0.1 }
+    ]
+  },
+  {
+    "id": "distortion_waw",
+    "type": "harvest",
+    "message": "",
+    "entries": [
+      { "drop": "corrupted_distortion_organ", "type": "flesh", "mass_ratio": 0.00001 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "blood", "type": "blood", "mass_ratio": 0.1 },
+      { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.33 },
+      { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.1 },
+      { "drop": "bone_human", "type": "flesh", "mass_ratio": 0.1 }
+    ]
+  },
+  {
+    "id": "distortion_aleph",
+    "type": "harvest",
+    "message": "",
+    "entries": [
+      { "drop": "corrupted_distortion_organ", "type": "flesh", "mass_ratio": 0.00002 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "blood", "type": "blood", "mass_ratio": 0.1 },
+      { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.33 },
+      { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.1 },
+      { "drop": "bone_human", "type": "flesh", "mass_ratio": 0.1 }
+    ]
+  }
+]

--- a/Items/recipes.json
+++ b/Items/recipes.json
@@ -38,5 +38,123 @@
       { "proficiency": "prof_wp_abnos2", "time_multiplier": 1, "skill_penalty": 0 }
     ],
     "book_learn": [ [ "p_bird_book", 0 ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "result": "tainted_enk",
+    "category": "CC_PM",
+    "subcategory": "CSC_PM_OTHER",
+    "skill_used": "survival",
+    "difficulty": 3,
+    "book_learn": [
+      [
+        "resjournalenk",
+        1
+      ]
+    ],
+    "proficiencies": [
+      {
+        "proficiency": "prof_wp_abnos0",
+        "time_multiplier": 1.2,
+        "learning_time_multiplier": 0.2,
+        "skill_penalty": 0
+      }
+    ],
+    "result_mult": 1,
+    "time": "20 m",
+    "autolearn": false,
+    "batch_time_factors": [
+      20,
+      1
+    ],
+    "qualities": [
+      {
+        "id": "BOIL",
+        "level": 1
+      },
+      {
+        "id": "CONCENTRATE",
+        "level": 1
+      }
+    ],
+    "tools": [
+      [
+        [
+          "water_boiling_heat",
+          1,
+          "LIST"
+        ]
+      ]
+    ],
+    "components": [
+      [
+        [
+          "tainted_distortion_organ",
+          1
+        ]
+      ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "result": "corrupted_enk",
+    "category": "CC_PM",
+    "subcategory": "CSC_PM_OTHER",
+    "skill_used": "survival",
+    "difficulty": 5,
+    "time": "20 m",
+    "book_learn": [
+      [
+        "resjournalenk",
+        1
+      ]
+    ],
+    "proficiencies": [
+      {
+        "proficiency": "prof_wp_abnos0",
+        "time_multiplier": 1.2,
+        "learning_time_multiplier": 0.2,
+        "skill_penalty": 0
+      }
+    ],
+    "result_mult": 1,
+    "autolearn": false,
+    "batch_time_factors": [
+      20,
+      1
+    ],
+    "qualities": [
+      {
+        "id": "BOIL",
+        "level": 1
+      },
+      {
+        "id": "CONCENTRATE",
+        "level": 1
+      },
+      {
+        "id": "CHEM",
+        "level": 3
+      }
+    ],
+    "tools": [
+      [
+        [
+          "water_boiling_heat",
+          1,
+          "LIST"
+        ]
+      ]
+    ],
+    "components": [
+      [
+        [
+          "corrupted_distortion_organ",
+          1
+        ]
+      ]
+    ]
   }
 ]

--- a/ScaryMonstersAndNiceSprites/Distortions.json
+++ b/ScaryMonstersAndNiceSprites/Distortions.json
@@ -28,7 +28,7 @@
     "families": [ "prof_wp_distortions0", "prof_wp_distortions1", "prof_wp_pecca" ],
     "vision_day": 35,
     "vision_night": 5,
-    "harvest": "mutant_human",
+    "harvest": "distortion_zayin",
     "flags": [ "SEES", "HEARS", "SMELLS", "PATH_AVOID_FALL", "BASHES", "PATH_AVOID_FIRE", "SWARMS", "WARM", "NO_BREATHE" ],
     "armor": { "electric": 3, "heat": 50, "bash": 7, "cut": 11, "stab": 15, "bullet": 21, "acid": 3 }
   },
@@ -61,7 +61,7 @@
     "families": [ "prof_wp_distortions0", "prof_wp_distortions1", "prof_wp_pecca" ],
     "vision_day": 35,
     "vision_night": 5,
-    "harvest": "mutant_human",
+    "harvest": "distortion_zayin",
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT", "PLAYER_WEAK" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "PATH_AVOID_FALL", "BASHES", "PATH_AVOID_FIRE", "SWARMS", "WARM" ],
     "armor": { "electric": 2, "heat": 3, "bash": 19, "cut": 9, "stab": 13, "bullet": 21, "acid": 1 }
@@ -102,7 +102,7 @@
     "families": [ "prof_wp_distortions0", "prof_wp_distortions1", "prof_wp_pecca" ],
     "vision_day": 35,
     "vision_night": 5,
-    "harvest": "mutant_human",
+    "harvest": "distortion_zayin",
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT", "PLAYER_WEAK" ],
     "flags": [
       "SEES",
@@ -158,7 +158,7 @@
     "families": [ "prof_wp_distortions0", "prof_wp_distortions1", "prof_wp_pecca" ],
     "vision_day": 35,
     "vision_night": 5,
-    "harvest": "mutant_human",
+    "harvest": "distortion_zayin",
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT", "PLAYER_WEAK" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "PATH_AVOID_FALL", "PATH_AVOID_FIRE", "SWARMS", "WARM" ],
     "armor": { "electric": 1, "heat": 0, "bash": 6, "cut": 0, "stab": 8, "bullet": 21, "acid": 5 }
@@ -207,7 +207,7 @@
     "families": [ "prof_wp_distortions0", "prof_wp_distortions1", "prof_wp_pecca" ],
     "vision_day": 35,
     "vision_night": 5,
-    "harvest": "mutant_human",
+    "harvest": "distortion_zayin",
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT", "PLAYER_WEAK" ],
     "flags": [
       "SEES",
@@ -253,7 +253,7 @@
     "families": [ "prof_wp_distortions0", "prof_wp_distortions1", "prof_wp_pecca" ],
     "vision_day": 35,
     "vision_night": 5,
-    "harvest": "mutant_human",
+    "harvest": "distortion_zayin",
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT", "PLAYER_WEAK" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "PATH_AVOID_FALL", "PATH_AVOID_FIRE", "SWARMS", "WARM", "NOHEAD", "NO_BREATHE" ],
     "armor": { "electric": 3, "heat": 5, "bash": 0, "cut": 8, "stab": 7, "bullet": 21, "acid": 5 }
@@ -287,7 +287,7 @@
     "families": [ "prof_wp_distortions0", "prof_wp_distortions1", "prof_wp_pecca" ],
     "vision_day": 35,
     "vision_night": 5,
-    "harvest": "mutant_human",
+    "harvest": "distortion_zayin",
     "death_drops": "zw_pecca",
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT", "PLAYER_WEAK" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "PATH_AVOID_FALL", "BASHES", "PATH_AVOID_FIRE", "SWARMS", "WARM" ],


### PR DESCRIPTION
Additions:
- Doubt now drops a broken Doubt that can be deconstructed for materials
- Four types of Enkephelin
- Harvest tables for distortions, producing some Enkephelin glands
- Recipes to extract Enk from glands, currently has no use
- Added new journals, some give practice recipes, one gives the above recipe

Changes:
- Polished Soda's descriptions, made it more obvious what the aura's do
- Gave Soda the ability to summon WellCheers at a health cost