### PR TITLE
Various fixes, Soda refactor

### DIFF
--- a/AnomalousThings/BookThatDontBelongToYou/Owner/EGO effects.json
+++ b/AnomalousThings/BookThatDontBelongToYou/Owner/EGO effects.json
@@ -85,19 +85,6 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "clear_spell_soda",
-    "effect": [
-      { "math": [ "u_spell_level('soda_can_weak_hook')", "=", "-1" ] },
-      { "math": [ "u_spell_level('soda_can_normal_hook')", "=", "-1" ] },
-      { "math": [ "u_spell_level('soda_armor_normal_hook')", "=", "-1" ] },
-	  { "math": [ "u_spell_level('soda_net_normal_hook')", "=", "-1" ] },
-      { "math": [ "u_spell_level('soda_armor_empower_hook')", "=", "-1" ] },
-      { "math": [ "u_spell_level('soda_can_empower_hook')", "=", "-1" ] },
-	  { "math": [ "u_spell_level('soda_net_empower_hook')", "=", "-1" ] }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "EOC_HOOK_92_SPELLBOOK_0",
     "eoc_type": "EVENT",
     "required_event": "gains_mutation",

--- a/AnomalousThings/BookThatDontBelongToYou/Owner/EGO spez.json
+++ b/AnomalousThings/BookThatDontBelongToYou/Owner/EGO spez.json
@@ -10,9 +10,9 @@
     "valid": false
   },
   {
-    "id": "EGO_92_stage_1",
+    "id": "EGO_92_invoke",
     "type": "SPELL",
-    "name": "[ט] EGO 9:2 stage 1 activation",
+    "name": "[ט] EGO 9:2 - Invoke Bond",
     "description": "Activate your bond with EGO 9:2, strengthening you and wreathing you in flame.",
     "valid_targets": [ "self" ],
     "effect": "effect_on_condition",
@@ -20,9 +20,8 @@
     "shape": "blast",
     "min_aoe": 0,
     "max_aoe": 0,
-    "min_duration": 600,
-    "max_duration": 6000,
-    "duration_increment": 600,
+    "min_duration": { "math": ["600 + (600 * (u_spell_level('EGO_92')^2))"] },
+    "duration_increment": 0,
     "base_casting_time": 200,
     "final_casting_time": 50,
     "casting_time_increment": -15,
@@ -32,7 +31,7 @@
     "energy_increment": -50,
     "energy_source": "STAMINA",
     "difficulty": 3,
-    "max_level": 10,
+    "max_level": 30,
     "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS" ]
   },
   {
@@ -40,10 +39,10 @@
     "id": "92_stage_1_activation",
     "condition": { "not": { "u_has_effect": "EGO_CD" } },
     "effect": [
-      { "u_add_effect": "EGO_CD", "duration": "5 minutes" },
+      { "u_add_effect": "EGO_CD", "duration":  { "math": ["300 + (6 * (u_spell_level('EGO_92_invoke')^2))"] } },
       { "math": [ "u_vitamin('emotion') -= 20" ] },
       {
-        "u_cast_spell": { "id": "EGO_92_stage_1_success", "hit_self": true, "min_level": { "math": [ "u_spell_level('EGO_92_stage_1')" ] } }
+        "u_cast_spell": { "id": "EGO_92_success", "hit_self": true, "min_level": { "math": [ "u_spell_level('EGO_92_invoke')" ] } }
       },
       { "math": [ "u_health() -= 3" ] },
       {
@@ -52,6 +51,10 @@
         "max_bonus": -200,
         "duration": "15 minutes",
         "decay_start": "5 minutes"
+      },
+      {
+        "run_eocs": "clear_spell_92",
+        "time_in_future": { "math": ["6 + (6 * (u_spell_level('EGO_92_invoke')^2))"] }
       }
     ],
     "false_effect": [
@@ -67,7 +70,7 @@
     ]
   },
   {
-    "id": "EGO_92_stage_1_success",
+    "id": "EGO_92_success",
     "type": "SPELL",
     "name": "[ט] EGO 9:2 stage 1 activation",
     "description": "Разжигает внутреннее пламя, на короткое время даруя силу и стойкость к огню.",
@@ -77,9 +80,8 @@
     "shape": "blast",
     "min_aoe": 0,
     "max_aoe": 0,
-    "min_duration": 600,
-    "max_duration": 6000,
-    "duration_increment": 600,
+    "min_duration": { "math": ["600 + (600 * (u_spell_level('EGO_92')^2))"] },
+    "duration_increment": 0,
     "base_casting_time": 0,
     "final_casting_time": 0,
     "spell_class": "EGO_92",
@@ -87,236 +89,108 @@
     "final_energy_cost": 0,
     "energy_source": "NONE",
     "difficulty": 3,
-    "max_level": 10,
+    "max_level": 30,
     "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS" ]
   },
   {
     "id": "EGO_92_stage_1_aura",
     "type": "ARMOR",
-    "name": "[ט] EGO 9:2 activated s1",
-    "description": "desc",
+    "name": "[ט] EGO 9:2 Aura",
+    "description": "A spiral of flame wreaths you, enhancing your capabilities beyond that of mortality. May your foes be burned as they strike at you, and warmth be your ally, not your foe.",
     "weight": "0 g",
     "volume": "0 ml",
     "material": [ "wind" ],
     "symbol": "0",
     "color": "white",
     "flags": [ "ZERO_WEIGHT", "NO_TAKEOFF" ],
-    "relic_data": { "passive_effects": [ { "id": "EGO_92_stage_1_ench" } ] }
+    "relic_data": { "passive_effects": [ { "id": "EGO_92_stage_1_ench" }, { "id": "EGO_92_stage_2_ench" }, { "id": "EGO_92_stage_3_ench" }, { "id": "EGO_92_invoke_ench" }, { "id": "EGO_92_invoke_ench3" } ] }
   },
   {
     "type": "enchantment",
     "id": "EGO_92_stage_1_ench",
     "has": "WORN",
-    "condition": "ALWAYS",
-    "hit_you_effect": [ { "id": "92_strike_hook", "once_in": 2 } ],
+    "condition": { "math": [ "u_spell_level('EGO_92_invoke') < 10" ] },
+    "hit_you_effect": [ { "id": "92_weak_strike", "once_in": 2 } ],
+    "mutations": [ "EGO_92_mutation_stage_1" ],
     "values": [
-      { "value": "LUMINATION", "add": { "math": [ "u_spell_level('EGO_92_stage_1') * 2" ] } },
+      { "value": "LUMINATION", "add": { "math": [ "u_spell_level('EGO_92_invoke') * 2" ] } },
       { "value": "CLIMATE_CONTROL_HEAT", "add": 20 },
       { "value": "CLIMATE_CONTROL_CHILL", "add": 10 }
     ],
-    "incoming_damage_mod": [ { "type": "heat", "add": { "math": [ "u_spell_level('EGO_92_stage_1') * 1.2" ] } } ]
-  },
-  {
-    "id": "92_strike_hook",
-    "type": "SPELL",
-    "name": "9:2 strike hook",
-    "description": "Hook to use levels of 9:2 ego in strike",
-    "valid_targets": [ "ally", "hostile" ],
-    "effect": "effect_on_condition",
-    "effect_str": "92_hook_1",
-    "shape": "blast",
-    "min_range": 1,
-    "max_range": 1,
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "min_duration": 600,
-    "max_duration": 6000,
-    "duration_increment": 600,
-    "base_casting_time": 200,
-    "final_casting_time": 50,
-    "casting_time_increment": -15,
-    "spell_class": "EGO_92",
-    "base_energy_cost": 3000,
-    "final_energy_cost": 500,
-    "energy_increment": -50,
-    "energy_source": "STAMINA",
-    "difficulty": 3,
-    "max_level": 10,
-    "flags": [ "SILENT" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "92_hook_1",
-    "effect": [
-      { "u_cast_spell": { "id": "92_weak_strike", "min_level": { "math": [ "u_spell_level('EGO_92_stage_1')" ] } } },
-      { "message": "Fush!", "type": "bad" }
-    ]
-  },
-  {
-    "id": "92_weak_strike",
-    "type": "SPELL",
-    "name": "9:2 strike stage 1",
-    "description": " desc",
-    "effect": "attack",
-    "shape": "blast",
-    "valid_targets": [ "ally", "hostile" ],
-    "flags": [ "LOUD", "SOMATIC", "NO_LEGS", "NO_HANDS", "NO_EXPLOSION_SFX" ],
-    "max_level": 10,
-    "min_damage": 1,
-    "max_damage": 3,
-    "damage_increment": 0.2,
-    "min_range": 1,
-    "max_range": 1,
-    "range_increment": 0,
-    "difficulty": 0,
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "spell_class": "EGO_92",
-    "base_casting_time": 200,
-    "final_casting_time": 100,
-    "casting_time_increment": -5,
-    "base_energy_cost": 140,
-    "damage_type": "heat",
-    "sound_description": "fush",
-    "energy_source": "NONE"
-  },
-  {
-    "id": "EGO_92_stage_2",
-    "type": "SPELL",
-    "name": "[ט] EGO 9:2 stage 2 activation",
-    "description": "Your bond with EGO 9:2 has strengthened, and you may call upon it more deeply.",
-    "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "92_stage_2_activation",
-    "shape": "blast",
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "min_duration": 600,
-    "max_duration": 6000,
-    "duration_increment": 600,
-    "base_casting_time": 200,
-    "final_casting_time": 50,
-    "casting_time_increment": -15,
-    "spell_class": "EGO_92",
-    "base_energy_cost": 5000,
-    "final_energy_cost": 500,
-    "energy_increment": -100,
-    "energy_source": "STAMINA",
-    "difficulty": 4,
-    "max_level": 10,
-    "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "92_stage_2_activation",
-    "condition": { "not": { "u_has_effect": "EGO_CD" } },
-    "effect": [
-      { "u_add_effect": "EGO_CD", "duration": "8 minutes" },
-      {
-        "switch": { "math": [ "u_vitamin('emotion')" ] },
-        "cases": [
-          {
-            "case": 0,
-            "effect": [
-              { "math": [ "u_vitamin('emotion') -= 20" ] },
-              {
-                "u_cast_spell": { "id": "EGO_92_stage_2_success", "min_level": { "math": [ "u_spell_level('EGO_92_stage_2')" ] } }
-              },
-              { "u_message": "Your emotion manifests, wreathing you in a glorious aura.", "type": "good" }
-            ]
-          },
-          {
-            "case": 50,
-            "effect": [
-              { "math": [ "u_vitamin('emotion') -= 50" ] },
-              {
-                "u_cast_spell": { "id": "EGO_92_stage_2_success", "min_level": { "math": [ "u_spell_level('EGO_92_stage_2')" ] } }
-              },
-              { "run_eocs": [ "92_sword_hook_eoc_1" ] },
-              { "run_eocs": [ "92_armor_hook_eoc_1" ] },
-              {
-                "u_message": "Your strong emotions coalesce into an glorious aura, and the armaments of a prophet.",
-                "type": "good"
-              }
-            ]
-          }
-        ]
-      },
-      { "math": [ "u_health() -= 14" ] },
-      {
-        "u_add_morale": "ego_morale",
-        "bonus": -40,
-        "max_bonus": -200,
-        "duration": "22 minutes",
-        "decay_start": "8 minutes"
-      },
-      {
-        "run_eocs": "clear_spell_92",
-        "time_in_future": { "math": [ "60 + (12 * u_spell_level('EGO_92_stage_2'))" ] }
-      }
-    ],
-    "false_effect": [
-      { "u_message": "EGO on cooldown!", "type": "bad" },
-      { "math": [ "u_health() -= 8" ] },
-      {
-        "u_add_morale": "ego_morale",
-        "bonus": -22,
-        "max_bonus": -200,
-        "duration": "22 minutes",
-        "decay_start": "8 minutes"
-      }
-    ]
-  },
-  {
-    "id": "EGO_92_stage_2_success",
-    "type": "SPELL",
-    "name": "[ט] EGO 9:2 stage 2 activation",
-    "description": "EGO spell activation desc stage 2",
-    "valid_targets": [ "self" ],
-    "effect": "spawn_item",
-    "effect_str": "EGO_92_stage_2_aura",
-    "shape": "blast",
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "min_duration": 6000,
-    "max_duration": 18000,
-    "duration_increment": 1200,
-    "base_casting_time": 0,
-    "final_casting_time": 0,
-    "spell_class": "EGO_92",
-    "base_energy_cost": 0,
-    "final_energy_cost": 0,
-    "energy_source": "NONE",
-    "difficulty": 4,
-    "max_level": 10,
-    "flags": [ "SILENT" ]
-  },
-  {
-    "id": "EGO_92_stage_2_aura",
-    "type": "ARMOR",
-    "name": "[ט] EGO 9:2 activated s2",
-    "description": "desc",
-    "weight": "0 g",
-    "volume": "0 ml",
-    "material": [ "wind" ],
-    "symbol": "0",
-    "color": "white",
-    "flags": [ "ZERO_WEIGHT", "NO_TAKEOFF" ],
-    "relic_data": { "passive_effects": [ { "id": "EGO_92_stage_2_ench" } ] }
+    "incoming_damage_mod": [ { "type": "heat", "add": { "math": [ "u_spell_level('EGO_92_invoke') * -1.2" ] } } ]
   },
   {
     "type": "enchantment",
     "id": "EGO_92_stage_2_ench",
     "has": "WORN",
-    "condition": "ALWAYS",
+    "condition": { "and": [ { "math": [ "u_spell_level('EGO_92_invoke') >= 10" ] }, { "math": [ "u_spell_level('EGO_92_invoke') < 20" ] } ] },
     "hit_you_effect": [ { "id": "92_strike_hook_2" } ],
     "mutations": [ "EGO_92_mutation_stage_2" ],
     "values": [
-      { "value": "LUMINATION", "add": { "math": [ "20 + u_spell_level('EGO_92_stage_1') * 2" ] } },
+      { "value": "LUMINATION", "add": { "math": [ "20 + u_spell_level('EGO_92_invoke') * 2" ] } },
       { "value": "CLIMATE_CONTROL_HEAT", "add": 50 },
       { "value": "CLIMATE_CONTROL_CHILL", "add": 20 }
     ],
-    "incoming_damage_mod": [ { "type": "heat", "add": { "math": [ "12 + u_spell_level('EGO_92_stage_2') * 1.3" ] } } ]
+    "incoming_damage_mod": [ { "type": "heat", "add": { "math": [ "-12 + u_spell_level('EGO_92_invoke') * -1.3" ] } } ]
+  },
+  {
+    "type": "enchantment",
+    "id": "EGO_92_stage_3_ench",
+    "has": "WORN",
+    "condition": { "and": [ { "math": [ "u_spell_level('EGO_92_invoke') >= 20" ] }, { "math": [ "u_spell_level('EGO_92_invoke') < 25" ] } ] },
+    "hit_you_effect": [ { "id": "92_strike_hook_3" } ],
+    "mutations": [ "EGO_92_mutation_stage_3" ],
+    "values": [
+      { "value": "LUMINATION", "add": { "math": [ "40 + u_spell_level('EGO_92_invoke') * 2" ] } },
+      { "value": "CLIMATE_CONTROL_HEAT", "add": 80 },
+      { "value": "CLIMATE_CONTROL_CHILL", "add": 60 }
+    ],
+    "incoming_damage_mod": [ { "type": "heat", "add": { "math": [ "-30 * u_spell_level('EGO_92_invoke') " ] } } ]
+  },
+  {
+    "type": "enchantment",
+    "id": "EGO_92_invoke_ench",
+    "has": "WORN",
+    "condition": { "math": [ "u_spell_level('EGO_92_invoke') >= 25" ] },
+    "hit_you_effect": [ { "id": "92_strike_hook_4" }, { "id": "cinder_stack", "hit_self": true, "once_in": 6 } ],
+    "mutations": [ "EGO_92_mutation_stage_4" ],
+    "values": [
+      { "value": "LUMINATION", "add": { "math": [ "60 + u_spell_level('EGO_92_invoke') * 5" ] } },
+      { "value": "CLIMATE_CONTROL_HEAT", "add": 500 },
+      { "value": "CLIMATE_CONTROL_CHILL", "add": 75 }
+    ],
+    "incoming_damage_mod": [ { "type": "heat", "add": { "math": [ "-300 * u_spell_level('EGO_92_invoke')" ] } } ]
+  },
+  {
+    "type": "enchantment",
+    "id": "EGO_92_invoke_ench1",
+    "has": "WIELD",
+    "condition": { "math": [ "u_spell_level('EGO_92_invoke') >= 25" ] },
+    "hit_you_effect": [ { "id": "92_sword_strike2" } ]
+  },
+  {
+    "type": "enchantment",
+    "id": "EGO_92_invoke_ench2",
+    "has": "WIELD",
+    "condition": { "and": [ { "math": [ "u_spell_level('EGO_92_invoke') >= 25" ] }, { "not": { "u_has_effect": "cinders", "intensity": 10 } } ] },
+    "hit_you_effect": [ { "id": "cinder_stack", "hit_self": true, "once_in": 3 } ]
+  },
+  {
+    "type": "enchantment",
+    "id": "EGO_92_invoke_ench3",
+    "has": "WORN",
+    "condition": { "and": [ { "math": [ "u_spell_level('EGO_92_invoke') >= 25" ] }, { "math": [ "u_spell_level('EGO_92_invoke') >= 25" ] } ] },
+    "hit_you_effect": [ { "id": "92_flame_hook_4", "once_in": 3 } ]
+  },
+  {
+    "type": "mutation",
+    "id": "EGO_92_mutation_stage_1",
+    "name": "[ט] Imperfect EGO 9:2 manifestation",
+    "points": 0,
+    "description": "EGO 9:2 mutation desc",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false
   },
   {
     "type": "mutation",
@@ -330,62 +204,83 @@
     "spells_learned": [ [ "92_sword_weak_hook", 1 ] ]
   },
   {
+    "type": "mutation",
+    "id": "EGO_92_mutation_stage_3",
+    "name": "[ט] EGO 9:2 manifestation",
+    "points": 0,
+    "description": "EGO 9:2 mutation desc",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "flags": [ "PROPHET_RESIST", "HEAT_IMMUNE" ],
+    "spells_learned": [ [ "92_sword_normal_hook", 1 ], [ "92_armor_normal_hook", 1 ] ]
+  },
+  {
+    "type": "mutation",
+    "id": "EGO_92_mutation_stage_4",
+    "name": "[ט] EGO 9:2 manifestation",
+    "points": 0,
+    "description": "EGO 9:2 mutation desc",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "flags": [ "PROPHET_RESIST", "HEAT_IMMUNE", "CLIMATE_CONTROL" ],
+    "spells_learned": [ [ "92_sword_empower_hook", 1 ], [ "92_armor_empower_hook", 1 ] ]
+  },
+  {
+    "id": "92_weak_strike",
+    "type": "SPELL",
+    "name": "9:2 strike stage 1",
+    "description": " desc",
+    "effect": "attack",
+    "shape": "blast",
+    "valid_targets": [ "ally", "hostile" ],
+    "flags": [ "LOUD", "SOMATIC", "NO_LEGS", "NO_HANDS", "NO_EXPLOSION_SFX" ],
+    "max_level": 1,
+    "min_damage": { "math": [ "1 + 0.2 * u_spell_level('EGO_92_invoke')" ] },
+    "max_damage": 3,
+    "min_range": 1,
+    "max_range": 1,
+    "range_increment": 0,
+    "difficulty": 0,
+    "min_aoe": 0,
+    "max_aoe": 0,
+    "spell_class": "EGO_92",
+    "base_casting_time": { "math": [ "200 - 15 * u_spell_level('EGO_92_invoke')" ] },
+    "final_casting_time": 50,
+    "base_energy_cost": { "math": [ "3000 - 50 * u_spell_level('EGO_92_invoke')" ] },
+    "final_energy_cost": 500,
+    "energy_increment": -50,
+    "damage_type": "heat",
+    "sound_description": "fush",
+    "message": "Fush!",
+    "energy_source": "NONE"
+  },
+  {
     "id": "92_sword_weak_hook",
     "type": "SPELL",
     "name": "[ט] Imperfect EGO 9:2 - Summon sword ",
     "description": "Call forth the imperfect blade of a prophet.",
     "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "92_sword_hook_eoc",
+    "effect": "spawn_item",
+    "effect_str": "92_sword_weak_item",
     "shape": "blast",
     "min_range": 0,
     "max_range": 0,
     "min_aoe": 0,
     "max_aoe": 0,
-    "min_duration": 200,
-    "max_duration": 200,
+    "min_duration": { "math": [ "2500 + 75 * u_spell_level('EGO_92_invoke')" ] },
+    "max_duration": 10000,
     "base_casting_time": 80,
     "final_casting_time": 80,
     "spell_class": "EGO_92",
     "base_energy_cost": 1000,
     "final_energy_cost": 1000,
     "energy_source": "STAMINA",
+    "message": "*A clot of flame appears in your hand, forms a sword and solidifies into a solid form*",
     "difficulty": 0,
     "max_level": 1,
     "flags": [ "SILENT", "NO_FAIL", "NO_LEGS" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "92_sword_hook_eoc",
-    "effect": [
-      { "u_cast_spell": { "id": "92_sword_weak", "min_level": { "math": [ "u_spell_level('EGO_92_stage_2')" ] } } },
-      {
-        "message": "*A clot of flame appears in your hand, forms a sword and solidifies into a solid form*",
-        "type": "bad"
-      }
-    ]
-  },
-  {
-    "id": "92_sword_weak",
-    "type": "SPELL",
-    "name": "9:2 weak sword summon true",
-    "description": " technical desc",
-    "valid_targets": [ "self" ],
-    "flags": [ "SILENT" ],
-    "min_damage": 1,
-    "max_damage": 1,
-    "effect": "spawn_item",
-    "effect_str": "92_sword_weak_item",
-    "shape": "blast",
-    "energy_source": "NONE",
-    "spell_class": "EGO_92",
-    "difficulty": 0,
-    "max_level": 10,
-    "base_casting_time": 80,
-    "base_energy_cost": 0,
-    "min_duration": 2500,
-    "max_duration": 10000,
-    "duration_increment": 75
   },
   {
     "id": "92_sword_weak_item",
@@ -411,42 +306,6 @@
   {
     "id": "92_strike_hook_2",
     "type": "SPELL",
-    "name": "9:2 strike hook",
-    "description": "Hook to use levels of 9:2 ego in strike",
-    "valid_targets": [ "ally", "hostile" ],
-    "effect": "effect_on_condition",
-    "effect_str": "92_hook_2",
-    "shape": "blast",
-    "min_range": 1,
-    "max_range": 1,
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "min_duration": 60000,
-    "max_duration": 600000,
-    "duration_increment": 60000,
-    "base_casting_time": 200,
-    "final_casting_time": 50,
-    "casting_time_increment": -15,
-    "spell_class": "EGO_92",
-    "base_energy_cost": 3000,
-    "final_energy_cost": 500,
-    "energy_increment": -50,
-    "energy_source": "STAMINA",
-    "difficulty": 4,
-    "max_level": 10,
-    "flags": [ "SILENT" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "92_hook_2",
-    "effect": [
-      { "u_cast_spell": { "id": "92_strike", "min_level": { "math": [ "u_spell_level('EGO_92_stage_2')" ] } } },
-      { "message": "WShh!", "type": "bad" }
-    ]
-  },
-  {
-    "id": "92_strike",
-    "type": "SPELL",
     "name": "9:2 strike stage 2",
     "description": " desc",
     "effect": "attack",
@@ -454,12 +313,10 @@
     "valid_targets": [ "ally", "hostile" ],
     "flags": [ "LOUD", "SOMATIC", "NO_LEGS", "NO_HANDS", "NO_EXPLOSION_SFX", "IGNITE_FLAMMABLE" ],
     "max_level": 10,
-    "min_damage": 3,
+    "min_damage": { "math": [ "3 + 0.3 * u_spell_level('EGO_92_invoke')" ] },
     "max_damage": 6,
-    "damage_increment": 0.3,
-    "min_pierce": 0,
+    "min_pierce": { "math": [ "0.3 * u_spell_level('EGO_92_invoke')" ] },
     "max_pierce": 3,
-    "pierce_increment": 0.3,
     "min_range": 1,
     "max_range": 1,
     "range_increment": 0,
@@ -467,221 +324,37 @@
     "min_aoe": 0,
     "max_aoe": 0,
     "spell_class": "EGO_92",
-    "base_casting_time": 200,
+    "base_casting_time": { "math": [ "200 - 5 * u_spell_level('EGO_92_invoke')" ] },
     "final_casting_time": 100,
-    "casting_time_increment": -5,
     "base_energy_cost": 140,
     "damage_type": "heat",
     "sound_description": "fush",
+    "message": "Wshh!",
     "energy_source": "NONE"
-  },
-  {
-    "id": "EGO_92_stage_3",
-    "type": "SPELL",
-    "name": "[ט] EGO 9:2 stage 3 activation",
-    "description": "Your bond with EGO 9:2 has grown deeper still, towards a vast depth of power.",
-    "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "92_stage_3_activation",
-    "shape": "blast",
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "min_duration": 600,
-    "max_duration": 6000,
-    "duration_increment": 600,
-    "base_casting_time": 200,
-    "final_casting_time": 50,
-    "casting_time_increment": -15,
-    "spell_class": "EGO_92",
-    "base_energy_cost": 5000,
-    "final_energy_cost": 500,
-    "energy_increment": -100,
-    "energy_source": "STAMINA",
-    "difficulty": 4,
-    "max_level": 10,
-    "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "92_stage_3_activation",
-    "condition": { "not": { "u_has_effect": "EGO_CD" } },
-    "effect": [
-      { "u_add_effect": "EGO_CD", "duration": "15 minutes" },
-      {
-        "switch": { "math": [ "u_vitamin('emotion')" ] },
-        "cases": [
-          {
-            "case": 0,
-            "effect": [
-              { "math": [ "u_vitamin('emotion') -= 20" ] },
-              {
-                "u_cast_spell": { "id": "EGO_92_stage_3_success", "min_level": { "math": [ "u_spell_level('EGO_92_stage_3')" ] } }
-              },
-              { "u_message": "Your emotion manifests, wreathing you in a glorious aura.", "type": "good" }
-            ]
-          },
-          {
-            "case": 50,
-            "effect": [
-              { "math": [ "u_vitamin('emotion') -= 50" ] },
-              {
-                "u_cast_spell": { "id": "EGO_92_stage_3_success", "min_level": { "math": [ "u_spell_level('EGO_92_stage_3')" ] } }
-              },
-              { "run_eocs": [ "92_sword_hook_eoc_2" ] },
-              { "run_eocs": [ "92_armor_hook_eoc_2" ] },
-              {
-                "u_message": "Your strong emotions coalesce into an glorious aura, and the armaments of a prophet.",
-                "type": "good"
-              }
-            ]
-          }
-        ]
-      },
-      { "math": [ "u_health() -= 20" ] },
-      {
-        "u_add_morale": "ego_morale",
-        "bonus": -85,
-        "max_bonus": -400,
-        "duration": "39 minutes",
-        "decay_start": "15 minutes"
-      },
-      {
-        "run_eocs": "clear_spell_92",
-        "time_in_future": { "math": [ "18 + (58.2 * u_spell_level('EGO_92_stage_3'))" ] }
-      }
-    ],
-    "false_effect": [
-      { "u_message": "EGO on cooldown!", "type": "bad" },
-      { "math": [ "u_health() -= 15" ] },
-      {
-        "u_add_morale": "ego_morale",
-        "bonus": -65,
-        "max_bonus": -400,
-        "duration": "39 minutes",
-        "decay_start": "15 minutes"
-      }
-    ]
-  },
-  {
-    "id": "EGO_92_stage_3_success",
-    "type": "SPELL",
-    "name": "[ט] EGO 9:2 stage 3 activation",
-    "description": "EGO spell activation desc stage 3",
-    "valid_targets": [ "self" ],
-    "effect": "spawn_item",
-    "effect_str": "EGO_92_stage_3_aura",
-    "shape": "blast",
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "min_duration": 1800,
-    "max_duration": 60000,
-    "duration_increment": 58200,
-    "base_casting_time": 0,
-    "final_casting_time": 0,
-    "spell_class": "EGO_92",
-    "base_energy_cost": 0,
-    "final_energy_cost": 0,
-    "energy_source": "NONE",
-    "difficulty": 4,
-    "max_level": 10,
-    "flags": [ "SILENT" ]
-  },
-  {
-    "id": "EGO_92_stage_3_aura",
-    "type": "ARMOR",
-    "name": "[ט] EGO 9:2 activated s3",
-    "description": "desc",
-    "weight": "0 g",
-    "volume": "0 ml",
-    "material": [ "wind" ],
-    "symbol": "0",
-    "color": "white",
-    "flags": [ "ZERO_WEIGHT", "NO_TAKEOFF" ],
-    "relic_data": { "passive_effects": [ { "id": "EGO_92_stage_3_ench" } ] }
-  },
-  {
-    "type": "enchantment",
-    "id": "EGO_92_stage_3_ench",
-    "has": "WORN",
-    "condition": "ALWAYS",
-    "hit_you_effect": [ { "id": "92_strike_hook_3" } ],
-    "mutations": [ "EGO_92_mutation_stage_3" ],
-    "values": [
-      { "value": "LUMINATION", "add": { "math": [ "40 + u_spell_level('EGO_92_stage_1') * 2" ] } },
-      { "value": "CLIMATE_CONTROL_HEAT", "add": 80 },
-      { "value": "CLIMATE_CONTROL_CHILL", "add": 60 }
-    ],
-    "incoming_damage_mod": [ { "type": "heat", "add": { "math": [ "30 * u_spell_level('EGO_92_stage_3') " ] } } ]
-  },
-  {
-    "type": "mutation",
-    "id": "EGO_92_mutation_stage_3",
-    "name": "[ט] EGO 9:2 manifestation",
-    "points": 0,
-    "description": "EGO 9:2 mutation desc",
-    "starting_trait": false,
-    "purifiable": false,
-    "valid": false,
-    "flags": [ "PROPHET_RESIST", "HEAT_IMMUNE" ],
-    "spells_learned": [ [ "92_sword_normal_hook", 1 ], [ "92_armor_normal_hook", 1 ] ]
-  },
+  },  
   {
     "id": "92_sword_normal_hook",
-    "type": "SPELL",
-    "name": "[ט] EGO 9:2 - Summon sword ",
-    "description": "Call forth the blade of a prophet.",
-    "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "92_sword_hook_eoc_2",
-    "shape": "blast",
-    "min_range": 0,
-    "max_range": 0,
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "min_duration": 200,
-    "max_duration": 200,
-    "base_casting_time": 80,
-    "final_casting_time": 80,
-    "spell_class": "EGO_92",
-    "base_energy_cost": 750,
-    "final_energy_cost": 750,
-    "energy_source": "STAMINA",
-    "difficulty": 0,
-    "max_level": 1,
-    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "92_sword_hook_eoc_2",
-    "effect": [
-      { "u_cast_spell": { "id": "92_sword_normal", "min_level": { "math": [ "u_spell_level('EGO_92_stage_3')" ] } } },
-      {
-        "message": "A clot of flame appears in your hand, forms a sword and solidifies into a solid form.",
-        "type": "bad"
-      }
-    ]
-  },
-  {
-    "id": "92_sword_normal",
     "type": "SPELL",
     "name": "9:2 sword summon true",
     "description": " technical desc",
     "valid_targets": [ "self" ],
-    "flags": [ "SILENT" ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
     "effect_str": "92_sword_item",
     "shape": "blast",
     "energy_source": "NONE",
-    "spell_class": "EGO_92",
     "difficulty": 0,
-    "max_level": 10,
+    "max_level": 1,
     "base_casting_time": 80,
-    "base_energy_cost": 0,
-    "min_duration": 1000,
+    "final_casting_time": 80,
+    "spell_class": "EGO_92",
+    "base_energy_cost": 750,
+    "final_energy_cost": 750,
+    "min_duration": { "math": [ "1000 + 2300 * u_spell_level('EGO_92_invoke')" ] },
     "max_duration": 24000,
-    "duration_increment": 2300
+    "message": "A clot of flame appears in your hand, forms a sword and solidifies into a solid form.",
+    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS" ]
   },
   {
     "id": "92_sword_item",
@@ -752,15 +425,15 @@
     "name": "[ט] EGO 9:2 - Summon armor",
     "description": "Call forth the armor of a prophet.",
     "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "92_armor_hook_eoc_2",
+    "effect": "spawn_item",
+    "effect_str": "92_armor_normal_item",
     "shape": "blast",
     "min_range": 0,
     "max_range": 0,
     "min_aoe": 0,
     "max_aoe": 0,
-    "min_duration": 20000,
-    "max_duration": 20000,
+    "min_duration": { "math": [ "1000 + 2300 * u_spell_level('EGO_92_invoke')" ] },
+    "max_duration": 24000,
     "base_casting_time": 80,
     "final_casting_time": 80,
     "spell_class": "EGO_92",
@@ -769,40 +442,8 @@
     "energy_source": "STAMINA",
     "difficulty": 0,
     "max_level": 1,
+    "message": "The flame enveloped you, but it does not burn, after which the armor of the Prophet materialized on you.",
     "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "NO_ARMS" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "92_armor_hook_eoc_2",
-    "effect": [
-      { "u_cast_spell": { "id": "92_armor_normal", "min_level": { "math": [ "u_spell_level('EGO_92_stage_3')" ] } } },
-      {
-        "message": "The flame enveloped you, but it does not burn, after which the armor of the Prophet materialized on you.",
-        "type": "bad"
-      }
-    ]
-  },
-  {
-    "id": "92_armor_normal",
-    "type": "SPELL",
-    "name": "9:2 armor summon true",
-    "description": " technical desc",
-    "valid_targets": [ "self" ],
-    "flags": [ "SILENT" ],
-    "min_damage": 1,
-    "max_damage": 1,
-    "effect": "spawn_item",
-    "effect_str": "92_armor_normal_item",
-    "shape": "blast",
-    "energy_source": "NONE",
-    "spell_class": "EGO_92",
-    "difficulty": 0,
-    "max_level": 10,
-    "base_casting_time": 80,
-    "base_energy_cost": 0,
-    "min_duration": 1000,
-    "max_duration": 24000,
-    "duration_increment": 2300
   },
   {
     "id": "92_armor_normal_item",
@@ -862,52 +503,17 @@
   {
     "id": "92_strike_hook_3",
     "type": "SPELL",
-    "name": "9:2 strike hook",
-    "description": "Hook to use levels of 9:2 ego in strike",
-    "valid_targets": [ "ally", "hostile" ],
-    "effect": "effect_on_condition",
-    "effect_str": "92_hook_3",
-    "shape": "blast",
-    "min_range": 1,
-    "max_range": 1,
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "min_duration": 60000,
-    "max_duration": 600000,
-    "duration_increment": 60000,
-    "base_casting_time": 200,
-    "final_casting_time": 50,
-    "casting_time_increment": -15,
-    "spell_class": "EGO_92",
-    "base_energy_cost": 3000,
-    "final_energy_cost": 500,
-    "energy_increment": -50,
-    "energy_source": "STAMINA",
-    "difficulty": 4,
-    "max_level": 10,
-    "flags": [ "SILENT" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "92_hook_3",
-    "effect": [ { "u_cast_spell": { "id": "92_strong_strike", "min_level": { "math": [ "u_spell_level('EGO_92_stage_3')" ] } } } ]
-  },
-  {
-    "id": "92_strong_strike",
-    "type": "SPELL",
     "name": "9:2 strike stage 3",
     "description": " desc",
     "effect": "attack",
     "shape": "blast",
     "valid_targets": [ "ally", "hostile" ],
     "flags": [ "LOUD", "SOMATIC", "NO_LEGS", "NO_HANDS", "NO_EXPLOSION_SFX" ],
-    "max_level": 10,
-    "min_damage": 3,
+    "max_level": 1,
+    "min_damage": { "math": [ "3 + 0.3 * u_spell_level('EGO_92_invoke')" ] },
     "max_damage": 6,
-    "damage_increment": 0.3,
-    "min_pierce": 3,
+    "min_pierce": { "math": [ "3 + 0.3 * u_spell_level('EGO_92_invoke')" ] },
     "max_pierce": 6,
-    "pierce_increment": 0.3,
     "min_range": 1,
     "max_range": 1,
     "range_increment": 0,
@@ -915,120 +521,17 @@
     "min_aoe": 0,
     "max_aoe": 0,
     "spell_class": "EGO_92",
-    "base_casting_time": 200,
+    "base_casting_time": { "math": [ "100 - 5 * u_spell_level('EGO_92_invoke')" ] },
     "final_casting_time": 100,
     "casting_time_increment": -5,
-    "base_energy_cost": 140,
+    "base_energy_cost": { "math": [ "3000 - 50 * u_spell_level('EGO_92_invoke')" ] },
+    "final_energy_cost": 500,
     "damage_type": "heat",
     "sound_description": "fush",
-    "energy_source": "NONE"
+    "energy_source": "STAMINA"
   },
   {
-    "id": "EGO_92_stage_4",
-    "type": "SPELL",
-    "name": "[ט] EGO 9:2 stage 4 activation",
-    "description": "Ignites your joint flame, granting great strength and resistance to fire for a short time.",
-    "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "92_stage_4_activation",
-    "shape": "blast",
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "min_duration": 600,
-    "max_duration": 6000,
-    "duration_increment": 600,
-    "base_casting_time": 100,
-    "final_casting_time": 10,
-    "casting_time_increment": -10,
-    "spell_class": "EGO_92",
-    "base_energy_cost": 100,
-    "final_energy_cost": 10,
-    "energy_increment": -10,
-    "energy_source": "STAMINA",
-    "difficulty": 4,
-    "max_level": 10,
-    "flags": [ "SILENT", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "92_stage_4_activation",
-    "condition": { "not": { "u_has_effect": "EGO_CD" } },
-    "effect": [
-      {
-        "switch": { "math": [ "u_vitamin('emotion')" ] },
-        "cases": [
-          {
-            "case": 0,
-            "effect": [
-              { "math": [ "u_vitamin('emotion') -= 20" ] },
-              {
-                "u_cast_spell": { "id": "EGO_92_stage_4_success", "min_level": { "math": [ "u_spell_level('EGO_92_stage_4')" ] } }
-              },
-              { "u_message": "Your emotion manifests, wreathing you in a glorious aura.", "type": "good" }
-            ]
-          },
-          {
-            "case": 50,
-            "effect": [
-              { "math": [ "u_vitamin('emotion') -= 50" ] },
-              {
-                "u_cast_spell": { "id": "EGO_92_stage_4_success", "min_level": { "math": [ "u_spell_level('EGO_92_stage_4')" ] } }
-              },
-              { "run_eocs": [ "92_sword_hook_eoc_3" ] },
-              { "run_eocs": [ "92_armor_hook_eoc_3" ] },
-              { "run_eocs": [ "candle_spawner" ] },
-              {
-                "u_message": "Your strong emotions coalesce into an glorious aura, and the armaments of a prophet.",
-                "type": "good"
-              }
-            ]
-          },
-          {
-            "case": 80,
-            "effect": [
-              { "math": [ "u_vitamin('emotion') -= 80" ] },
-              {
-                "u_cast_spell": { "id": "EGO_92_stage_4_success", "min_level": { "math": [ "u_spell_level('EGO_92_stage_4')" ] } }
-              },
-              { "run_eocs": [ "92_sword_hook_eoc_3" ] },
-              { "run_eocs": [ "92_armor_hook_eoc_3" ] },
-              {
-                "u_cast_spell": { "id": "EGO_92_stage_4_explosion", "hit_self": true, "min_level": { "math": [ "u_spell_level('EGO_92_stage_4')" ] } }
-              },
-              { "run_eocs": [ "candle_spawner" ] },
-              { "run_eocs": [ "candle_spawner" ] },
-              {
-                "u_message": "Your overflowing emotions explode outwards, causing brimstone flame as they manifest into incredible armaments.",
-                "type": "mixed"
-              }
-            ]
-          }
-        ]
-      },
-      { "u_add_effect": "EGO_CD", "duration": "15 minutes" },
-      { "math": [ "u_health() -= 10" ] },
-      {
-        "u_add_morale": "ego_morale",
-        "bonus": -50,
-        "max_bonus": -400,
-        "duration": "70 minutes",
-        "decay_start": "22 minutes"
-      }
-    ],
-    "false_effect": [
-      { "u_message": "EGO on cooldown!", "type": "bad" },
-      { "math": [ "u_health() -= 2" ] },
-      {
-        "u_add_morale": "ego_morale",
-        "bonus": -11,
-        "max_bonus": -400,
-        "duration": "70 minutes",
-        "decay_start": "22 minutes"
-      }
-    ]
-  },
-  {
-    "id": "EGO_92_stage_4_explosion",
+    "id": "EGO_92_invoke_explosion",
     "type": "SPELL",
     "name": "[ט] EGO 9:2 Stage 4 Explosion",
     "description": "Erupt into flames like a glorious phoenix.",
@@ -1060,64 +563,6 @@
     "sound_description": "a crackle!"
   },
   {
-    "id": "EGO_92_stage_4_success",
-    "type": "SPELL",
-    "name": "[ט] EGO 9:2 stage 4 activation",
-    "description": "EGO spell activation desc stage 4",
-    "valid_targets": [ "self" ],
-    "effect": "spawn_item",
-    "effect_str": "EGO_92_stage_4_aura",
-    "shape": "blast",
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "min_duration": 12000,
-    "max_duration": 36000,
-    "duration_increment": 2400,
-    "base_casting_time": 0,
-    "final_casting_time": 0,
-    "spell_class": "EGO_92",
-    "base_energy_cost": 0,
-    "final_energy_cost": 0,
-    "energy_source": "NONE",
-    "difficulty": 4,
-    "max_level": 10,
-    "flags": [ "SILENT" ]
-  },
-  {
-    "id": "EGO_92_stage_4_aura",
-    "type": "ARMOR",
-    "name": "[ט] EGO 9:2 activated s4",
-    "description": "desc",
-    "weight": "0 g",
-    "volume": "0 ml",
-    "material": [ "wind" ],
-    "symbol": "0",
-    "color": "white",
-    "flags": [ "ZERO_WEIGHT", "NO_TAKEOFF", "PROPHET_RESIST" ],
-    "relic_data": { "passive_effects": [ { "id": "EGO_92_stage_4_ench" }, { "id": "EGO_92_stage_4_ench3" } ] }
-  },
-  {
-    "type": "enchantment",
-    "id": "EGO_92_stage_4_ench",
-    "has": "WORN",
-    "condition": "ALWAYS",
-    "hit_you_effect": [ { "id": "92_strike_hook_4" }, { "id": "cinder_stack", "hit_self": true, "once_in": 6 } ],
-    "mutations": [ "EGO_92_mutation_stage_4" ],
-    "values": [
-      { "value": "LUMINATION", "add": { "math": [ "60 + u_spell_level('EGO_92_stage_1') * 5" ] } },
-      { "value": "CLIMATE_CONTROL_HEAT", "add": 500 },
-      { "value": "CLIMATE_CONTROL_CHILL", "add": 75 }
-    ],
-    "incoming_damage_mod": [ { "type": "heat", "add": { "math": [ "300 * u_spell_level('EGO_92_stage_4') " ] } } ]
-  },
-  {
-    "type": "enchantment",
-    "id": "EGO_92_stage_4_ench3",
-    "has": "WORN",
-    "condition": { "compare_string": [ "yes", { "u_val": "living_flame_on" } ] },
-    "hit_you_effect": [ { "id": "92_flame_hook_4", "once_in": 3 } ]
-  },
-  {
     "id": "92_gaze_hook_4",
     "type": "SPELL",
     "name": "[ט] EGO 9:2 - Gaze",
@@ -1126,8 +571,8 @@
     "effect": "effect_on_condition",
     "effect_str": "92_gaze_hook_eoc",
     "shape": "blast",
-    "min_range": { "math": [ "u_spell_level('EGO_92_stage_4') * 3.5" ] },
-    "max_range": { "math": [ "u_spell_level('EGO_92_stage_4') * 3.5" ] },
+    "min_range": { "math": [ "u_spell_level('EGO_92_invoke') * 3.5" ] },
+    "max_range": { "math": [ "u_spell_level('EGO_92_invoke') * 3.5" ] },
     "min_aoe": 0,
     "max_aoe": 0,
     "min_duration": 200,
@@ -1158,8 +603,8 @@
     "min_duration": 6000,
     "max_duration": 6000,
     "effect_str": "92_gaze_effect",
-    "min_range": { "math": [ "u_spell_level('EGO_92_stage_4') * 3.5" ] },
-    "max_range": { "math": [ "u_spell_level('EGO_92_stage_4') * 3.5" ] },
+    "min_range": { "math": [ "u_spell_level('EGO_92_invoke') * 3.5" ] },
+    "max_range": { "math": [ "u_spell_level('EGO_92_invoke') * 3.5" ] },
     "range_increment": 0,
     "difficulty": 0,
     "min_dot": 0,
@@ -1207,7 +652,7 @@
       {
         "u_cast_spell": {
           "id": "92_gaze",
-          "min_level": { "math": [ "(n_spell_level('EGO_92_stage_4') / 2) + n_effect_intensity('cinders')" ] }
+          "min_level": { "math": [ "(n_spell_level('EGO_92_invoke') / 2) + n_effect_intensity('cinders')" ] }
         }
       }
     ],
@@ -1323,7 +768,7 @@
           "id": "92_flame_explosion",
           "min_level": {
             "math": [
-              "1 + (n_spell_level('EGO_92_stage_4') / 5) + (n_effect_intensity('cinders') / 2) + (2 *(n_monsters_nearby('mon_candle_allied', 'radius': 60, 'attitude': 'friendly'))) "
+              "1 + (n_spell_level('EGO_92_invoke') / 5) + (n_effect_intensity('cinders') / 2) + (2 *(n_monsters_nearby('mon_candle_allied', 'radius': 60, 'attitude': 'friendly'))) "
             ]
           },
           "hit_self": true
@@ -1443,33 +888,22 @@
     "immune_flags": [ "PROPHET_RESIST", "PROPHET_MINION" ],
     "scaling_mods": {  }
   },
-  {
-    "type": "mutation",
-    "id": "EGO_92_mutation_stage_4",
-    "name": "[ט] EGO 9:2 manifestation",
-    "points": 0,
-    "description": "EGO 9:2 mutation desc",
-    "starting_trait": false,
-    "purifiable": false,
-    "valid": false,
-    "flags": [ "PROPHET_RESIST", "HEAT_IMMUNE", "CLIMATE_CONTROL" ],
-    "spells_learned": [ [ "92_sword_empower_hook", 1 ], [ "92_armor_empower_hook", 1 ] ]
-  },
+  
   {
     "id": "92_sword_empower_hook",
     "type": "SPELL",
     "name": "[ט] EGO 9:2 - Summon sword and grimoire",
     "description": "Call forth the blade and grimoire of a True Prophet.",
     "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "92_sword_hook_eoc_3",
+    "effect": "spawn_item",
+    "effect_str": "92_sword_item_empower",
     "shape": "blast",
     "min_range": 0,
     "max_range": 0,
     "min_aoe": 0,
     "max_aoe": 0,
-    "min_duration": 200,
-    "max_duration": 200,
+    "min_duration": { "math": [ "6000 + 7200 * u_spell_level('EGO_92_invoke')" ] },
+    "max_duration": 78000,
     "base_casting_time": 35,
     "final_casting_time": 35,
     "spell_class": "EGO_92",
@@ -1478,40 +912,8 @@
     "energy_source": "STAMINA",
     "difficulty": 0,
     "max_level": 1,
+    "message": "A clot of flame appears in your hand, forms a sword and solidifies into a solid form.",
     "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_LEGS", "NO_FAIL" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "92_sword_hook_eoc_3",
-    "effect": [
-      { "u_cast_spell": { "id": "92_sword_empower", "min_level": { "math": [ "u_spell_level('EGO_92_stage_4')" ] } } },
-      {
-        "message": "A clot of flame appears in your hand, forms a sword and solidifies into a solid form.",
-        "type": "bad"
-      }
-    ]
-  },
-  {
-    "id": "92_sword_empower",
-    "type": "SPELL",
-    "name": "9:2 sword summon true",
-    "description": " technical desc",
-    "valid_targets": [ "self" ],
-    "flags": [ "SILENT" ],
-    "min_damage": 1,
-    "max_damage": 1,
-    "effect": "spawn_item",
-    "effect_str": "92_sword_item_empower",
-    "shape": "blast",
-    "energy_source": "NONE",
-    "spell_class": "EGO_92",
-    "difficulty": 0,
-    "max_level": 10,
-    "base_casting_time": 80,
-    "base_energy_cost": 0,
-    "min_duration": 6000,
-    "max_duration": 78000,
-    "duration_increment": 7200
   },
   {
     "id": "92_sword_item_empower",
@@ -1636,20 +1038,6 @@
     "spells_learned": [ [ "92_big_summon", 1 ], [ "92_evaporize", 1 ] ]
   },
   {
-    "type": "enchantment",
-    "id": "EGO_92_stage_4_ench1",
-    "has": "WIELD",
-    "condition": "ALWAYS",
-    "hit_you_effect": [ { "id": "92_sword_strike2" } ]
-  },
-  {
-    "type": "enchantment",
-    "id": "EGO_92_stage_4_ench2",
-    "has": "WIELD",
-    "condition": { "not": { "u_has_effect": "cinders", "intensity": 10 } },
-    "hit_you_effect": [ { "id": "cinder_stack", "hit_self": true, "once_in": 3 } ]
-  },
-  {
     "id": "92_sword_strike2",
     "type": "SPELL",
     "name": "9:2 strike stage 4 sword",
@@ -1682,15 +1070,15 @@
     "name": "[ט] EGO 9:2 - Summon armor",
     "description": "Call forth the armor of a True Prophet.",
     "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "92_armor_hook_eoc_3",
+    "effect": "spawn_item",
+    "effect_str": "92_armor_empower_item",
     "shape": "blast",
     "min_range": 0,
     "max_range": 0,
     "min_aoe": 0,
     "max_aoe": 0,
-    "min_duration": 200,
-    "max_duration": 200,
+    "min_duration": { "math": [ "6000 + 7200 * u_spell_level('EGO_92_invoke')" ] },
+    "max_duration": 78000,
     "base_casting_time": 80,
     "final_casting_time": 80,
     "spell_class": "EGO_92",
@@ -1700,39 +1088,6 @@
     "difficulty": 0,
     "max_level": 1,
     "flags": [ "SILENT", "NO_ARMS", "NO_FAIL", "NO_HANDS" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "92_armor_hook_eoc_3",
-    "effect": [
-      { "u_cast_spell": { "id": "92_armor_empower", "min_level": { "math": [ "u_spell_level('EGO_92_stage_4')" ] } } },
-      {
-        "message": "The flame envelopes you, but it does not burn, after which the armor of the Prophet materialized on you.",
-        "type": "bad"
-      }
-    ]
-  },
-  {
-    "id": "92_armor_empower",
-    "type": "SPELL",
-    "name": "9:2 armor summon true",
-    "description": " technical desc",
-    "valid_targets": [ "self" ],
-    "flags": [ "SILENT" ],
-    "min_damage": 1,
-    "max_damage": 1,
-    "effect": "spawn_item",
-    "effect_str": "92_armor_empower_item",
-    "shape": "blast",
-    "energy_source": "NONE",
-    "spell_class": "EGO_92",
-    "difficulty": 0,
-    "max_level": 10,
-    "base_casting_time": 80,
-    "base_energy_cost": 0,
-    "min_duration": 6000,
-    "max_duration": 78000,
-    "duration_increment": 7200
   },
   {
     "id": "92_armor_empower_item",
@@ -1757,11 +1112,11 @@
         "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
       }
     ],
-    "relic_data": { "passive_effects": [ { "id": "EGO_92_stage_4_ench_armor" } ] }
+    "relic_data": { "passive_effects": [ { "id": "EGO_92_invoke_ench_armor" } ] }
   },
   {
     "type": "enchantment",
-    "id": "EGO_92_stage_4_ench_armor",
+    "id": "EGO_92_invoke_ench_armor",
     "has": "WORN",
     "condition": "ALWAYS",
     "values": [
@@ -1792,57 +1147,16 @@
   {
     "id": "92_strike_hook_4",
     "type": "SPELL",
-    "name": "9:2 strike hook",
-    "description": "Hook to use levels of 9:2 ego in strike",
-    "valid_targets": [ "ally", "hostile" ],
-    "effect": "effect_on_condition",
-    "effect_str": "92_hook_4",
-    "shape": "blast",
-    "min_range": 1,
-    "max_range": 1,
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "min_duration": 600,
-    "max_duration": 6000,
-    "duration_increment": 600,
-    "base_casting_time": 200,
-    "final_casting_time": 50,
-    "casting_time_increment": -15,
-    "spell_class": "EGO_92",
-    "base_energy_cost": 3000,
-    "final_energy_cost": 500,
-    "energy_increment": -50,
-    "energy_source": "STAMINA",
-    "difficulty": 4,
-    "max_level": 10,
-    "flags": [ "SILENT" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "92_hook_4",
-    "effect": [
-      {
-        "u_cast_spell": { "id": "92_hyper_strike", "hit_self": true, "min_level": { "math": [ "u_spell_level('EGO_92_stage_4')" ] } }
-      },
-      { "message": "FFASHH", "type": "bad" }
-    ]
-  },
-  {
-    "id": "92_hyper_strike",
-    "type": "SPELL",
     "name": "[ט] EGO 9:2 strike stage 4",
     "description": " desc",
     "effect": "attack",
     "shape": "blast",
     "valid_targets": [ "ally", "hostile" ],
     "flags": [ "LOUD", "SOMATIC", "NO_LEGS", "NO_HANDS", "NO_EXPLOSION_SFX" ],
-    "max_level": 10,
-    "min_damage": 2,
+    "min_damage": { "math": [ "2 + 2 * u_spell_level('EGO_92_invoke')" ] },
     "max_damage": 15,
-    "damage_increment": 2,
-    "min_pierce": 5,
+    "min_pierce": { "math": [ "5 + 5 * u_spell_level('EGO_92_invoke')" ] },
     "max_pierce": 20,
-    "pierce_increment": 5,
     "min_range": 1,
     "max_range": 1,
     "range_increment": 0,
@@ -1850,12 +1164,12 @@
     "min_aoe": 1,
     "max_aoe": 1,
     "spell_class": "EGO_92",
-    "base_casting_time": 200,
+    "base_casting_time": { "math": [ "200 - 5 * u_spell_level('EGO_92_invoke')" ] },
     "final_casting_time": 100,
-    "casting_time_increment": -5,
     "base_energy_cost": 140,
     "damage_type": "heat",
     "sound_description": "fush",
+    "message": "FFASHH",
     "energy_source": "STAMINA"
   },
   {
@@ -2048,14 +1362,14 @@
   {
     "type": "effect_on_condition",
     "id": "92_longing_eoc",
-    "effect": [ { "u_cast_spell": { "id": "92_longing_explosion", "min_level": { "math": [ "n_spell_level('EGO_92_stage_4')" ] } } } ]
+    "effect": [ { "u_cast_spell": { "id": "92_longing_explosion", "min_level": { "math": [ "n_spell_level('EGO_92_invoke')" ] } } } ]
   },
   {
     "type": "effect_on_condition",
     "id": "92_knowledge_eoc",
     "condition": { "math": [ "u_effect_intensity('92_knowledge_effect')", "==", "3" ] },
     "effect": [
-      { "npc_cast_spell": { "id": "92_knowledge_spell", "min_level": { "math": [ "n_spell_level('EGO_92_stage_4')" ] } } },
+      { "npc_cast_spell": { "id": "92_knowledge_spell", "min_level": { "math": [ "n_spell_level('EGO_92_invoke')" ] } } },
       { "u_lose_effect": "92_knowledge_effect" }
     ],
     "false_effect": [ { "u_add_effect": "92_knowledge_effect", "duration": "1 minutes" } ]
@@ -2115,8 +1429,8 @@
     "max_duration": 500,
     "max_level": 1,
     "difficulty": -11,
-    "base_casting_time": { "math": [ "150 / u_spell_level('EGO_92_stage_4')" ] },
-    "base_energy_cost": { "math": [ "2500 - 150 * u_spell_level('EGO_92_stage_4')" ] },
+    "base_casting_time": { "math": [ "150 / u_spell_level('EGO_92_invoke')" ] },
+    "base_energy_cost": { "math": [ "2500 - 150 * u_spell_level('EGO_92_invoke')" ] },
     "energy_source": "STAMINA",
     "flags": [ "NO_FAIL", "NO_HANDS", "NO_LEGS", "HOSTILE_SUMMON", "RANDOM_AOE", "RANDOM_DURATION" ]
   },
@@ -2135,7 +1449,7 @@
     "max_aoe": 0,
     "min_duration": 1000,
     "max_duration": 1000,
-    "base_casting_time": { "math": [ "200 / u_spell_level('EGO_92_stage_4')" ] },
+    "base_casting_time": { "math": [ "200 / u_spell_level('EGO_92_invoke')" ] },
     "final_casting_time": 50,
     "casting_time_increment": -15,
     "spell_class": "EGO_92",
@@ -2171,7 +1485,7 @@
     "max_aoe": { "math": [ "1 + (u_monsters_nearby('mon_candle_allied', 'radius': 60, 'attitude': 'friendly') / 2)" ] },
     "min_damage": { "math": [ "9 * u_monsters_nearby('mon_candle_allied', 'radius': 60, 'attitude': 'friendly')" ] },
     "max_damage": { "math": [ "9 * u_monsters_nearby('mon_candle_allied', 'radius': 60, 'attitude': 'friendly')" ] },
-    "base_casting_time": { "math": [ "300 - 25 * u_spell_level('EGO_92_stage_4')" ] },
+    "base_casting_time": { "math": [ "300 - 25 * u_spell_level('EGO_92_invoke')" ] },
     "final_casting_time": 50,
     "casting_time_increment": -15,
     "spell_class": "EGO_92",
@@ -2193,9 +1507,9 @@
     "effect": "effect_on_condition",
     "effect_str": "92_gaze_explode_eoc",
     "shape": "blast",
-    "min_range": { "math": [ "u_spell_level('EGO_92_stage_4') * 3.5" ] },
-    "max_range": { "math": [ "u_spell_level('EGO_92_stage_4') * 3.5" ] },
-    "base_casting_time": { "math": [ "300 - 25 * u_spell_level('EGO_92_stage_4')" ] },
+    "min_range": { "math": [ "u_spell_level('EGO_92_invoke') * 3.5" ] },
+    "max_range": { "math": [ "u_spell_level('EGO_92_invoke') * 3.5" ] },
+    "base_casting_time": { "math": [ "300 - 25 * u_spell_level('EGO_92_invoke')" ] },
     "final_casting_time": 50,
     "casting_time_increment": -15,
     "spell_class": "EGO_92",
@@ -2264,8 +1578,8 @@
     "max_duration": 500,
     "max_level": 1,
     "difficulty": -11,
-    "base_casting_time": { "math": [ "300 - 25 * u_spell_level('EGO_92_stage_4')" ] },
-    "base_energy_cost": { "math": [ "3000 / u_spell_level('EGO_92_stage_4')" ] },
+    "base_casting_time": { "math": [ "300 - 25 * u_spell_level('EGO_92_invoke')" ] },
+    "base_energy_cost": { "math": [ "3000 / u_spell_level('EGO_92_invoke')" ] },
     "energy_source": "STAMINA",
     "flags": [ "NO_FAIL", "NO_HANDS", "NO_LEGS", "HOSTILE_SUMMON", "RANDOM_AOE", "RANDOM_DURATION" ]
   },

--- a/AnomalousThings/BookThatDontBelongToYou/what eocs.json
+++ b/AnomalousThings/BookThatDontBelongToYou/what eocs.json
@@ -226,60 +226,23 @@
     "type": "effect_on_condition",
     "id": "92_ego_evolve",
     "effect": [
-      {
-        "if": {
-          "and": [
-            { "math": [ "u_spell_level('EGO_92_stage_1')", "<", "10" ] },
-            { "math": [ "u_spell_level('EGO_92_stage_2')", "==", "-1" ] },
-            { "math": [ "u_spell_level('EGO_92_stage_3')", "==", "-1" ] },
-            { "math": [ "u_spell_level('EGO_92_stage_4')", "==", "-1" ] }
-          ]
-        },
+      { 
+        "if": { "math": [ "u_spell_level('EGO_92_invoke')", "==", "-1" ] },
         "then": [
-          { "math": [ "u_spell_level('EGO_92_stage_1')", "+=", "1" ] },
+          { "math": [ "u_spell_level('EGO_92_invoke')", "=", "1" ] },
           {
-            "u_message": "You feel a slight tickling somewhere in the back of your head, which gradually goes somewhere deeper into the brain."
-          },
-          { "u_consume_item": "skin_prophecy_evo_page", "count": 1 }
-        ],
-        "else": {
-          "if": {
-            "and": [
-              { "math": [ "u_spell_level('EGO_92_stage_2')", "<", "10" ] },
-              { "math": [ "u_spell_level('EGO_92_stage_3')", "==", "-1" ] },
-              { "math": [ "u_spell_level('EGO_92_stage_4')", "==", "-1" ] }
-            ]
-          },
-          "then": [
-            { "math": [ "u_spell_level('EGO_92_stage_2')", "+=", "1" ] },
-            { "u_message": "Your thoughts are clear but at the same time as if they don't belong to you." },
-            { "math": [ "u_spell_level('EGO_92_stage_1')", "=", "-1" ] },
-            { "u_consume_item": "skin_prophecy_evo_page", "count": 1 }
-          ],
-          "else": {
-            "if": {
-              "and": [
-                { "math": [ "u_spell_level('EGO_92_stage_3')", "<", "10" ] },
-                { "math": [ "u_spell_level('EGO_92_stage_4')", "==", "-1" ] }
-              ]
-            },
-            "then": [
-              { "math": [ "u_spell_level('EGO_92_stage_3')", "+=", "1" ] },
-              {
-                "u_message": "you feel the blood in your veins heating up and it almost hurts, but everything abruptly subsides, replaced by a cold inside your stomach."
-              },
-              { "math": [ "u_spell_level('EGO_92_stage_2')", "=", "-1" ] },
-              { "u_consume_item": "skin_prophecy_evo_page", "count": 1 }
-            ],
-            "else": [
-              { "math": [ "u_spell_level('EGO_92_stage_4')", "+=", "1" ] },
-              { "u_message": "You feel your understanding of EGO_92_stage_4 deepen! Its power grows." },
-              { "math": [ "u_spell_level('EGO_92_stage_3')", "=", "-1" ] },
-              { "u_consume_item": "skin_prophecy_evo_page", "count": 1 }
-            ]
+            "u_message": "The page burns its words into your soul, no longer are you simply a reader of the apocrypha, but the prophet themselves. The world will be consumed by a fire, the fire of your bond with the being you instinctively recognise now - 9:2.",
+            "popup": true
           }
-        }
-      }
+        ],
+        "else": [ 
+          { "math": [ "u_spell_level('EGO_92_invoke')", "+=", "1" ] },
+          {
+            "u_message": "you feel the blood in your veins heating up and it almost hurts, but everything abruptly subsides, replaced by a cold inside your stomach."
+          }
+        ]
+      },
+      { "u_consume_item": "skin_prophecy_evo_page", "count": 1 }
     ]
   },
   {

--- a/AnomalousThings/Wellcheers/Soda/EGO Soda.json
+++ b/AnomalousThings/Wellcheers/Soda/EGO Soda.json
@@ -10,40 +10,40 @@
     "valid": false
   },
   {
-    "id": "EGO_soda_stage_1",
+    "id": "EGO_soda",
     "type": "SPELL",
-    "name": "[ז] EGO Soda stage 1 activation",
+    "name": "[ז] EGO Soda - Invoke Bond",
     "description": "Activate your bond with Soda, strengthening you and granting you the ability to give enemies the slip. However, any contact with an EGO takes a toll.",
     "valid_targets": [ "self" ],
     "effect": "effect_on_condition",
-    "effect_str": "soda_stage_1_activation",
+    "effect_str": "soda_activation",
     "shape": "blast",
     "min_aoe": 0,
     "max_aoe": 0,
     "min_duration": 600,
-    "max_duration": 6000,
+    "max_duration": 24000,
     "duration_increment": 600,
     "base_casting_time": 200,
-    "final_casting_time": 50,
-    "casting_time_increment": -15,
+    "final_casting_time": 25,
+    "casting_time_increment": -5,
     "spell_class": "EGO_Soda",
     "base_energy_cost": 3000,
     "final_energy_cost": 500,
-    "energy_increment": -50,
+    "energy_increment": -100,
     "energy_source": "STAMINA",
     "difficulty": 3,
-    "max_level": 10,
+    "max_level": 30,
     "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS" ]
   },
   {
     "type": "effect_on_condition",
-    "id": "soda_stage_1_activation",
+    "id": "soda_activation",
     "condition": { "not": { "u_has_effect": "EGO_CD" } },
     "effect": [
       { "u_add_effect": "EGO_CD", "duration": "5 minutes" },
       { "math": [ "u_vitamin('emotion') -= 20" ] },
       {
-        "u_cast_spell": { "id": "EGO_soda_stage_1_success", "hit_self": true, "min_level": { "math": [ "u_spell_level('EGO_soda_stage_1')" ] } }
+        "u_cast_spell": { "id": "EGO_soda_success", "hit_self": true, "min_level": { "math": [ "u_spell_level('EGO_soda')" ] } }
       },
       { "math": [ "u_health() -= 3" ] },
       {
@@ -53,7 +53,11 @@
         "duration": "15 minutes",
         "decay_start": "5 minutes"
       },
-	  { "run_eocs": "soda_chat_stage_1" }
+      {
+        "run_eocs": "clear_spells_soda",
+        "time_in_future": { "math": ["600 + 600 * u_spell_level('EGO_soda')"] }
+      },
+      { "run_eocs": "soda_chat_stage_1" }
     ],
     "false_effect": [
       { "u_message": "EGO on cooldown!", "type": "bad" },
@@ -68,18 +72,18 @@
     ]
   },
   {
-    "id": "EGO_soda_stage_1_success",
+    "id": "EGO_soda_success",
     "type": "SPELL",
-    "name": "[ז] EGO Soda Invoke Bond - Stage 1",
+    "name": "[ז] EGO Soda Invoke Bond",
     "description": "",
     "valid_targets": [ "self" ],
     "effect": "spawn_item",
-    "effect_str": "EGO_soda_stage_1_aura",
+    "effect_str": "EGO_soda_aura",
     "shape": "blast",
     "min_aoe": 0,
     "max_aoe": 0,
     "min_duration": 600,
-    "max_duration": 6000,
+    "max_duration": 18000,
     "duration_increment": 600,
     "base_casting_time": 0,
     "final_casting_time": 0,
@@ -88,13 +92,13 @@
     "final_energy_cost": 0,
     "energy_source": "NONE",
     "difficulty": 3,
-    "max_level": 10,
-    "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS" ]
+    "max_level": 30,
+    "flags": [ "SILENT", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS" ]
   },
   {
-    "id": "EGO_soda_stage_1_aura",
+    "id": "EGO_soda_aura",
     "type": "ARMOR",
-    "name": "[ז] EGO Soda Pale Aura",
+    "name": "[ז] EGO Soda Aura",
     "description": "You feel Soda's presence in your mind, alien, twisting and writhing, yet granting you power beyond any mere mortal. While the bond is active you sense you'll be slightly harder to knock down, better at dodging, and find it easier to throw items.",
     "weight": "0 g",
     "volume": "0 ml",
@@ -102,19 +106,58 @@
     "symbol": "0",
     "color": "white",
     "flags": [ "ZERO_WEIGHT", "NO_TAKEOFF" ],
-    "relic_data": { "passive_effects": [ { "id": "EGO_soda_stage_1_ench" } ] }
+    "relic_data": { "passive_effects": [ { "id": "EGO_soda_stage_1" }, { "id": "EGO_soda_stage_2" }, { "id": "EGO_soda_stage_3" }, { "id": "EGO_soda_stage_4" } ] }
   },
   {
     "type": "enchantment",
-    "id": "EGO_soda_stage_1_ench",
+    "id": "EGO_soda_stage_1",
     "has": "WORN",
-    "condition": "ALWAYS",
-	"mutations": [ "EGO_soda_mutation_stage_1" ],
+    "condition": { "math": [ "u_spell_level('EGO_soda') < 10" ] },
+    "mutations": [ "EGO_soda_mutation_stage_1" ],
     "values": [
-      { "value": "THROW_STR", "add": { "math": [ "u_spell_level('EGO_soda_stage_1') / 2" ] } },
+      { "value": "THROW_STR", "add": { "math": [ "u_spell_level('EGO_soda') / 2" ] } },
       { "value": "SCENT_MASK", "add": 100 },
-      { "value": "DODGE_CHANCE", "add": { "math": [ "u_spell_level('EGO_soda_stage_1') / 4" ] } },
-	  { "value": "KNOCKDOWN_RESIST", "add": 10 }
+      { "value": "DODGE_CHANCE", "add": { "math": [ "u_spell_level('EGO_soda') / 4" ] } },
+      { "value": "KNOCKDOWN_RESIST", "add": 10 }
+    ]
+  },
+  {
+    "type": "enchantment",
+    "id": "EGO_soda_stage_2",
+    "has": "WORN",
+    "condition": { "and": [ { "math": [ "u_spell_level('EGO_soda') >= 10" ] }, { "math": [ "u_spell_level('EGO_soda') < 20" ] } ] },
+    "mutations": [ "EGO_soda_mutation_stage_2" ],
+    "values": [
+      { "value": "THROW_STR", "add": { "math": [ "u_spell_level('EGO_soda')" ] } },
+      { "value": "SCENT_MASK", "add": 150 },
+      { "value": "DODGE_CHANCE", "add": { "math": [ "u_spell_level('EGO_soda') / 3" ] } },
+      { "value": "KNOCKDOWN_RESIST", "add": 20 }
+    ]
+  },
+  {
+    "type": "enchantment",
+    "id": "EGO_soda_stage_3",
+    "has": "WORN",
+    "condition": { "and": [ { "math": [ "u_spell_level('EGO_soda') >= 20" ] }, { "math": [ "u_spell_level('EGO_soda') < 25" ] } ] },
+    "mutations": [ "EGO_soda_mutation_stage_3" ],
+    "values": [
+      { "value": "THROW_STR", "add": { "math": [ "u_spell_level('EGO_soda') * 1.5" ] } },
+      { "value": "SCENT_MASK", "add": 200 },
+      { "value": "DODGE_CHANCE", "add": { "math": [ "u_spell_level('EGO_soda') / 2" ] } },
+      { "value": "KNOCKDOWN_RESIST", "add": 30 }
+    ]
+  },
+  {
+    "type": "enchantment",
+    "id": "EGO_soda_stage_4",
+    "has": "WORN",
+    "condition": { "math": [ "u_spell_level('EGO_soda') >= 25" ] },
+    "mutations": [ "EGO_soda_mutation_stage_4" ],
+    "values": [
+      { "value": "THROW_STR", "add": { "math": [ "u_spell_level('EGO_soda') * 2" ] } },
+      { "value": "SCENT_MASK", "add": 250 },
+      { "value": "DODGE_CHANCE", "add": { "math": [ "u_spell_level('EGO_soda')" ] } },
+      { "value": "KNOCKDOWN_RESIST", "add": 40 }
     ]
   },
   {
@@ -128,143 +171,6 @@
     "valid": false
   },
   {
-    "id": "EGO_soda_stage_2",
-    "type": "SPELL",
-    "name": "[ז] EGO Soda Invoke Bond - Stage 2",
-    "description": "Your bond with Soda has strengthened, and you may call upon it more deeply. However, any contact with an EGO takes a toll.",
-    "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "soda_stage_2_activation",
-    "shape": "blast",
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "min_duration": 600,
-    "max_duration": 6000,
-    "duration_increment": 600,
-    "base_casting_time": 200,
-    "final_casting_time": 50,
-    "casting_time_increment": -15,
-    "spell_class": "EGO_Soda",
-    "base_energy_cost": 5000,
-    "final_energy_cost": 500,
-    "energy_increment": -100,
-    "energy_source": "STAMINA",
-    "difficulty": 4,
-    "max_level": 10,
-    "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "soda_stage_2_activation",
-    "condition": { "not": { "u_has_effect": "EGO_CD" } },
-    "effect": [
-      { "u_add_effect": "EGO_CD", "duration": "8 minutes" },
-      {
-        "switch": { "math": [ "u_vitamin('emotion')" ] },
-        "cases": [
-          {
-            "case": 0,
-            "effect": [
-              { "math": [ "u_vitamin('emotion') -= 20" ] },
-              {
-                "u_cast_spell": { "id": "EGO_soda_stage_2_success", "min_level": { "math": [ "u_spell_level('EGO_soda_stage_2')" ] } }
-              },
-              { "u_message": "Your emotion manifests, bursting forwards in a rush of speed.", "type": "good" }
-            ]
-          },
-          {
-            "case": 50,
-            "effect": [
-              { "math": [ "u_vitamin('emotion') -= 50" ] },
-              {
-                "u_cast_spell": { "id": "EGO_soda_stage_2_success", "min_level": { "math": [ "u_spell_level('EGO_soda_stage_2')" ] } }
-              },
-              { "run_eocs": [ "soda_can_hook_eoc_1" ] },
-              {
-                "u_message": "Your strong emotions coalesce into a rush of speed, a can of Wellcheers forming in your hand.",
-                "type": "good"
-              }
-            ]
-          }
-        ]
-      },
-      { "math": [ "u_health() -= 14" ] },
-      {
-        "u_add_morale": "ego_morale",
-        "bonus": -40,
-        "max_bonus": -200,
-        "duration": "22 minutes",
-        "decay_start": "8 minutes"
-      },
-      {
-        "run_eocs": "clear_spell_soda",
-        "time_in_future": { "math": [ "60 + (12 * u_spell_level('EGO_soda_stage_2'))" ] }
-      },
-	  { "run_eocs": "soda_chat_stage_2" }
-    ],
-    "false_effect": [
-      { "u_message": "EGO on cooldown!", "type": "bad" },
-      { "math": [ "u_health() -= 8" ] },
-      {
-        "u_add_morale": "ego_morale",
-        "bonus": -22,
-        "max_bonus": -200,
-        "duration": "22 minutes",
-        "decay_start": "8 minutes"
-      }
-    ]
-  },
-  {
-    "id": "EGO_soda_stage_2_success",
-    "type": "SPELL",
-    "name": "[ז] EGO Soda stage 2 activation",
-    "description": "EGO spell activation desc stage 2",
-    "valid_targets": [ "self" ],
-    "effect": "spawn_item",
-    "effect_str": "EGO_soda_stage_2_aura",
-    "shape": "blast",
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "min_duration": 6000,
-    "max_duration": 18000,
-    "duration_increment": 1200,
-    "base_casting_time": 0,
-    "final_casting_time": 0,
-    "spell_class": "EGO_Soda",
-    "base_energy_cost": 0,
-    "final_energy_cost": 0,
-    "energy_source": "NONE",
-    "difficulty": 4,
-    "max_level": 10,
-    "flags": [ "SILENT" ]
-  },
-  {
-    "id": "EGO_soda_stage_2_aura",
-    "type": "ARMOR",
-    "name": "[ז] EGO Soda Insubstantial Aura",
-    "description": "You feel Soda's now familiar aura encase you, it's words more understandable, and sharing your mind less jarring. While the bond is active you sense you'll be harder to knock down, better at dodging, and find it easier to throw items.",
-    "weight": "0 g",
-    "volume": "0 ml",
-    "material": [ "wind" ],
-    "symbol": "0",
-    "color": "white",
-    "flags": [ "ZERO_WEIGHT", "NO_TAKEOFF" ],
-    "relic_data": { "passive_effects": [ { "id": "EGO_soda_stage_2_ench" } ] }
-  },
-  {
-    "type": "enchantment",
-    "id": "EGO_soda_stage_2_ench",
-    "has": "WORN",
-    "condition": "ALWAYS",
-    "mutations": [ "EGO_soda_mutation_stage_2" ],
-    "values": [
-      { "value": "THROW_STR", "add": { "math": [ "u_spell_level('EGO_soda_stage_2')" ] } },
-      { "value": "SCENT_MASK", "add": 150 },
-      { "value": "DODGE_CHANCE", "add": { "math": [ "u_spell_level('EGO_soda_stage_2') / 3" ] } },
-	  { "value": "KNOCKDOWN_RESIST", "add": 20 }
-    ]
-  },
-  {
     "type": "mutation",
     "id": "EGO_soda_mutation_stage_2",
     "name": "[ז] Imperfect Soda manifestation",
@@ -273,87 +179,56 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "spells_learned": [ [ "EGO_soda_summon_can", 1 ] ]
+    "spells_learned": [ [ "EGO_soda_summon_can_weak", 1 ] ]
   },
   {
-    "id": "EGO_soda_summon_can",
+    "type": "mutation",
+    "id": "EGO_soda_mutation_stage_3",
+    "name": "[ז] EGO Soda manifestation",
+    "points": 0,
+    "description": "EGO Soda mutation desc",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "spells_learned": [ [ "EGO_soda_summon_can_normal", 1 ], [ "EGO_soda_summon_armour_normal", 1 ], [ "EGO_soda_summon_net_normal", 1 ], [ "EGO_soda_summon_wellcheers", 1 ] ]
+  },
+  {
+    "type": "mutation",
+    "id": "EGO_soda_mutation_stage_4",
+    "name": "[ז] EGO Soda manifestation",
+    "points": 0,
+    "description": "EGO Soda mutation desc",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "spells_learned": [ [ "EGO_soda_summon_can_empower", 1 ], [ "EGO_soda_summon_armour_empower", 1 ], [ "EGO_soda_summon_net_empower", 1 ], [ "EGO_soda_summon_wellcheers", 1 ] ]
+  },
+  {
+    "id": "EGO_soda_summon_can_weak",
     "type": "SPELL",
     "name": "[ז] Imperfect EGO Soda - Summon WellCheersBomb",
     "description": "Call forth a WellCheers can from the aether - one primed to be thrown at those who offend the might of WellCheers.",
     "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "soda_can_hook_eoc_1",
+    "effect": "spawn_item",
+    "effect_str": "soda_can_weak_item_act",
     "shape": "blast",
     "min_range": 0,
     "max_range": 0,
     "min_aoe": 0,
     "max_aoe": 0,
-    "min_duration": 200,
-    "max_duration": 200,
+    "min_duration": { "math": [ "2500 + (75 * u_spell_level('EGO_soda'))" ] },
+    "max_duration": 10000,
+    "duration_increment": 75,
     "base_casting_time": 80,
     "final_casting_time": 80,
     "spell_class": "EGO_Soda",
     "base_energy_cost": 200,
     "final_energy_cost": 200,
     "energy_source": "STAMINA",
+    "message": "Swiping your hand through the air, a cold metal touches your skin, the icy, refreshing touch of WellCheers.",
     "difficulty": 0,
     "max_level": 1,
-    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "soda_can_hook_eoc_1",
-    "effect": [
-      { "u_cast_spell": { "id": "soda_can_weak", "min_level": { "math": [ "u_spell_level('EGO_soda_stage_2')" ] } } },
-      {
-        "message": "Swiping your hand through the air, a cold metal touches your skin, the icy, refreshing touch of WellCheers.",
-        "type": "bad"
-      }
-    ]
-  },
-  {
-    "id": "soda_can_weak_hook",
-    "type": "SPELL",
-    "name": "Soda weak can summon true",
-    "description": " technical desc",
-    "valid_targets": [ "self" ],
-    "flags": [ "SILENT" ],
-    "min_damage": 1,
-    "max_damage": 1,
-    "effect": "spawn_item",
-    "effect_str": "soda_can_weak_item",
-    "shape": "blast",
-    "energy_source": "NONE",
-    "spell_class": "EGO_Soda",
-    "difficulty": 0,
-    "max_level": 10,
-    "base_casting_time": 80,
-    "base_energy_cost": 0,
-    "min_duration": 2500,
-    "max_duration": 10000,
-    "duration_increment": 75
-  },
-  {
-    "id": "soda_can_weak_item",
-    "type": "GENERIC",
-    "name": { "str": "<color_red>Can of WellCheers</color>" },
-    "description": "A can of delightfully refreshing WellCheers, but one you know not to taste - it is primed for destruction.",
-    "looks_like": "can_drink",
-    "symbol": "w",
-    "color": "light_gray",
-    "price": 0,
-    "price_postapoc": 0,
-    "melee_damage": { "bash": 2 },
-	"thrown_damage": [ { "damage_type": "bash", "amount": 5 } ],
-	"relic_data": { "passive_effects": [ { "id": "can_throwing_ench_2" } ] },
-	"use_action": {
-      "need_wielding": true,
-      "target": "soda_can_weak_item_act",
-      "msg": "You pull the tab on the soda can, it hisses audibly. You better throw it and run!",
-      "target_timer": "5 seconds",
-      "type": "transform"
-    },
-	"copy-from": "well_can"
+    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "PERMANENT" ]
   },
   {
     "id": "soda_can_weak_item_act",
@@ -366,17 +241,20 @@
     "price": 0,
     "price_postapoc": 0,
     "melee_damage": { "bash": 2 },
-	"thrown_damage": [ { "damage_type": "bash", "amount": 6 } ],
-	"relic_data": { "passive_effects": [ { "id": "can_throwing_ench" } ] },
-	"countdown_action": {
+    "thrown_damage": [ { "damage_type": "bash", "amount": 6 } ],
+    "relic_data": { "passive_effects": [ { "id": "can_throwing_ench" } ] },
+    "countdown_interval": "5 seconds",
+    "flags": [
+      "SPAWN_ACTIVE"
+    ],
+    "countdown_action": {
       "type": "explosion",
       "fields_radius": 1,
-      "do_flashbang": true,
       "fields_type": "fd_acid",
       "fields_min_intensity": 1,
       "fields_max_intensity": 1
     },
-	"copy-from": "well_can"
+    "copy-from": "well_can"
   },
   {
     "type": "enchantment",
@@ -386,233 +264,31 @@
     "skills": [ { "value": "throw", "add": 1 } ]
   },
   {
-    "id": "EGO_soda_stage_3",
-    "type": "SPELL",
-    "name": "[ז] EGO Soda Invoke Bond - Stage 3",
-    "description": "Your bond with Soda has grown deeper still, towards a vast depth of power. Call upon it, however, any contact with an EGO takes a toll.",
-    "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "soda_stage_3_activation",
-    "shape": "blast",
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "min_duration": 600,
-    "max_duration": 6000,
-    "duration_increment": 600,
-    "base_casting_time": 200,
-    "final_casting_time": 50,
-    "casting_time_increment": -15,
-    "spell_class": "EGO_Soda",
-    "base_energy_cost": 5000,
-    "final_energy_cost": 500,
-    "energy_increment": -100,
-    "energy_source": "STAMINA",
-    "difficulty": 4,
-    "max_level": 10,
-    "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "soda_stage_3_activation",
-    "condition": { "not": { "u_has_effect": "EGO_CD" } },
-    "effect": [
-      { "u_add_effect": "EGO_CD", "duration": "15 minutes" },
-      {
-        "switch": { "math": [ "u_vitamin('emotion')" ] },
-        "cases": [
-          {
-            "case": 0,
-            "effect": [
-              { "math": [ "u_vitamin('emotion') -= 20" ] },
-              {
-                "u_cast_spell": { "id": "EGO_soda_stage_3_success", "min_level": { "math": [ "u_spell_level('EGO_soda_stage_3')" ] } }
-              },
-              { "u_message": "Your emotion manifests, bursting forwards in a rush of speed.", "type": "good" }
-            ]
-          },
-          {
-            "case": 50,
-            "effect": [
-              { "math": [ "u_vitamin('emotion') -= 50" ] },
-              {
-                "u_cast_spell": { "id": "EGO_soda_stage_3_success", "min_level": { "math": [ "u_spell_level('EGO_soda_stage_3')" ] } }
-              },
-              { "run_eocs": [ "soda_can_hook_eoc_2" ] },
-              { "run_eocs": [ "soda_armor_hook_eoc_2" ] },
-              {
-                "u_message": "Your strong emotions coalesce into a rush of speed, a can of Wellcheers forming in your hand, and the protective armour of a shrimp snapping around you.",
-                "type": "good"
-              }
-            ]
-          }
-        ]
-      },
-      { "math": [ "u_health() -= 20" ] },
-      {
-        "u_add_morale": "ego_morale",
-        "bonus": -85,
-        "max_bonus": -400,
-        "duration": "39 minutes",
-        "decay_start": "15 minutes"
-      },
-      {
-        "run_eocs": "clear_spell_soda",
-        "time_in_future": { "math": [ "18 + (58.2 * u_spell_level('EGO_soda_stage_3'))" ] }
-      },
-	  { "run_eocs": "soda_chat_stage_3" }
-    ],
-    "false_effect": [
-      { "u_message": "EGO on cooldown!", "type": "bad" },
-      { "math": [ "u_health() -= 15" ] },
-      {
-        "u_add_morale": "ego_morale",
-        "bonus": -65,
-        "max_bonus": -400,
-        "duration": "39 minutes",
-        "decay_start": "15 minutes"
-      }
-    ]
-  },
-  {
-    "id": "EGO_soda_stage_3_success",
-    "type": "SPELL",
-    "name": "[ז] EGO Soda stage 3 activation",
-    "description": "EGO spell activation desc stage 3",
-    "valid_targets": [ "self" ],
-    "effect": "spawn_item",
-    "effect_str": "EGO_soda_stage_3_aura",
-    "shape": "blast",
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "min_duration": 1800,
-    "max_duration": 60000,
-    "duration_increment": 58200,
-    "base_casting_time": 0,
-    "final_casting_time": 0,
-    "spell_class": "EGO_Soda",
-    "base_energy_cost": 0,
-    "final_energy_cost": 0,
-    "energy_source": "NONE",
-    "difficulty": 4,
-    "max_level": 10,
-    "flags": [ "SILENT" ]
-  },
-  {
-    "id": "EGO_soda_stage_3_aura",
-    "type": "ARMOR",
-    "name": "[ז] EGO Soda Vivid Aura",
-    "description": "You feel Soda moving alongside you, a familiar friend now, even as they share your own skin, manifesting arms and armour at your call. While the bond is active you sense you'll be much harder to knock down, better at dodging, and find it easier to throw items.",
-    "weight": "0 g",
-    "volume": "0 ml",
-    "material": [ "wind" ],
-    "symbol": "0",
-    "color": "white",
-    "flags": [ "ZERO_WEIGHT", "NO_TAKEOFF" ],
-    "relic_data": { "passive_effects": [ { "id": "EGO_soda_stage_3_ench" } ] }
-  },
-  {
-    "type": "enchantment",
-    "id": "EGO_soda_stage_3_ench",
-    "has": "WORN",
-    "condition": "ALWAYS",
-    "mutations": [ "EGO_soda_mutation_stage_3" ],
-    "values": [
-      { "value": "THROW_STR", "add": { "math": [ "1 + u_spell_level('EGO_soda_stage_3') * 1.5" ] } },
-      { "value": "SCENT_MASK", "add": 200 },
-      { "value": "DODGE_CHANCE", "add": { "math": [ "2 + u_spell_level('EGO_soda_stage_3') / 2" ] } },
-	    { "value": "KNOCKDOWN_RESIST", "add": 30 }
-    ]
-  },
-  {
-    "type": "mutation",
-    "id": "EGO_soda_mutation_stage_3",
-    "name": "[ז] EGO Soda manifestation",
-    "points": 0,
-    "description": "EGO Soda mutation desc",
-    "starting_trait": false,
-    "purifiable": false,
-    "valid": false,
-    "spells_learned": [ [ "soda_can_normal_hook", 1 ], [ "soda_armor_normal_hook", 1 ], [ "soda_net_empower_hook", 1 ], [ "soda_summon_wellcheers_hook", 1 ] ]
-  },
-  {
-    "id": "soda_can_normal_hook",
+    "id": "EGO_soda_summon_can_normal",
     "type": "SPELL",
     "name": "[ז] EGO Soda - Summon WellCheersBomb",
     "description": "Call forth a delectably deadly can of WellCheers.",
     "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "soda_can_hook_eoc_2",
+    "effect": "spawn_item",
+    "effect_str": "soda_can_item_act",
     "shape": "blast",
     "min_range": 0,
     "max_range": 0,
     "min_aoe": 0,
     "max_aoe": 0,
-    "min_duration": 200,
-    "max_duration": 200,
+    "min_duration": { "math": [ "2500 + (2300 * u_spell_level('EGO_soda'))" ] },
+    "max_duration": 24000,
+    "duration_increment": 2300,
     "base_casting_time": 80,
     "final_casting_time": 80,
     "spell_class": "EGO_Soda",
     "base_energy_cost": 150,
     "final_energy_cost": 150,
     "energy_source": "STAMINA",
+    "message": "Swiping your hand through the air, a cold metal touches your skin, the icy, refreshing touch of WellCheers.",
     "difficulty": 0,
     "max_level": 1,
-    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "soda_can_hook_eoc_2",
-    "effect": [
-      { "u_cast_spell": { "id": "soda_can_normal", "min_level": { "math": [ "u_spell_level('EGO_soda_stage_3')" ] } } },
-      {
-        "message": "Swiping your hand through the air, a cold metal touches your skin, the icy, refreshing touch of WellCheers.",
-        "type": "bad"
-      }
-    ]
-  },
-  {
-    "id": "soda_can_normal",
-    "type": "SPELL",
-    "name": "Soda can summon true",
-    "description": " technical desc",
-    "valid_targets": [ "self" ],
-    "flags": [ "SILENT" ],
-    "min_damage": 1,
-    "max_damage": 1,
-    "effect": "spawn_item",
-    "effect_str": "soda_can_item",
-    "shape": "blast",
-    "energy_source": "NONE",
-    "spell_class": "EGO_Soda",
-    "difficulty": 0,
-    "max_level": 10,
-    "base_casting_time": 80,
-    "base_energy_cost": 0,
-    "min_duration": 1000,
-    "max_duration": 24000,
-    "duration_increment": 2300
-  },
-  {
-    "id": "soda_can_item",
-    "type": "GENERIC",
-    "name": { "str": "<color_red>Can of WellCheers</color>" },
-    "description": "A can of delightfully refreshing WellCheers, but one you know not to taste - it is primed for destruction.",
-    "looks_like": "can_drink",
-    "symbol": "w",
-    "color": "light_gray",
-    "price": 0,
-    "price_postapoc": 0,
-    "melee_damage": { "bash": 2 },
-	"thrown_damage": [ { "damage_type": "bash", "amount": 8 } ],
-	"relic_data": { "passive_effects": [ { "id": "can_throwing_ench_2" } ] },
-	"use_action": {
-      "need_wielding": true,
-      "target": "soda_can_item_act",
-      "msg": "You pull the tab on the soda can, it hisses audibly. You better throw it and run!",
-      "target_timer": "5 seconds",
-      "type": "transform"
-    },
-	"copy-from": "well_can"
+    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "PERMANENT" ]
   },
   {
     "id": "soda_can_item_act",
@@ -625,16 +301,20 @@
     "price": 0,
     "price_postapoc": 0,
     "melee_damage": { "bash": 2 },
-	"thrown_damage": [ { "damage_type": "bash", "amount": 8 } ],
-	"relic_data": { "passive_effects": [ { "id": "can_throwing_ench_2" } ] },
-	"countdown_action": {
+    "thrown_damage": [ { "damage_type": "bash", "amount": 8 } ],
+    "relic_data": { "passive_effects": [ { "id": "can_throwing_ench_2" } ] },
+    "countdown_interval": "5 seconds",
+    "flags": [
+      "SPAWN_ACTIVE"
+    ],
+    "countdown_action": {
       "type": "explosion",
       "fields_radius": 1,
       "fields_type": "fd_acid",
       "fields_min_intensity": 1,
       "fields_max_intensity": 2
     },
-	"copy-from": "well_can"
+    "copy-from": "well_can"
   },
   {
     "type": "enchantment",
@@ -644,62 +324,31 @@
     "skills": [ { "value": "throw", "add": 2 } ]
   },
   {
-    "id": "soda_net_normal_hook",
+    "id": "EGO_soda_summon_net_normal",
     "type": "SPELL",
     "name": "[ז] EGO Soda - Summon Shrimping Net",
     "description": "Call forth a net with which to fuel the WellCheers need for shrimp.",
     "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "soda_net_hook_eoc_2",
+    "effect": "spawn_item",
+    "effect_str": "soda_net_item",
     "shape": "blast",
     "min_range": 0,
     "max_range": 0,
     "min_aoe": 0,
     "max_aoe": 0,
-    "min_duration": 200,
-    "max_duration": 200,
+    "min_duration": { "math": [ "2500 + (2300 * u_spell_level('EGO_soda'))" ] },
+    "max_duration": 24000,
+    "duration_increment": 2300,
     "base_casting_time": 80,
     "final_casting_time": 80,
     "spell_class": "EGO_Soda",
     "base_energy_cost": 150,
     "final_energy_cost": 150,
     "energy_source": "STAMINA",
+    "message": "Woven cord patches itself together into your outstretched hand, until a pristine woven net is formed.",
     "difficulty": 0,
     "max_level": 1,
     "flags": [ "SILENT", "NO_FAIL", "NO_LEGS" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "soda_net_hook_eoc_2",
-    "effect": [
-      { "u_cast_spell": { "id": "soda_net_normal", "min_level": { "math": [ "u_spell_level('EGO_soda_stage_3')" ] } } },
-      {
-        "message": "Woven cord patches itself together into your outstretched hand, until a pristine woven net is formed.",
-        "type": "bad"
-      }
-    ]
-  },
-  {
-    "id": "soda_net_normal",
-    "type": "SPELL",
-    "name": "Soda net summon true",
-    "description": " technical desc",
-    "valid_targets": [ "self" ],
-    "flags": [ "SILENT" ],
-    "min_damage": 1,
-    "max_damage": 1,
-    "effect": "spawn_item",
-    "effect_str": "soda_net_item",
-    "shape": "blast",
-    "energy_source": "NONE",
-    "spell_class": "EGO_Soda",
-    "difficulty": 0,
-    "max_level": 10,
-    "base_casting_time": 80,
-    "base_energy_cost": 0,
-    "min_duration": 1000,
-    "max_duration": 24000,
-    "duration_increment": 2300
   },
   {
     "id": "soda_net_item",
@@ -708,77 +357,46 @@
     "description": "A woven tangle of cord forming an incredibly light net, yet you can sense its desire to cling, wrap and tangle.",
     "looks_like": "net",
     "symbol": "n",
-	"material": "b_silk",
+    "material": "b_silk",
     "color": "light_gray",
-	"weight": "600 g",
+    "weight": "600 g",
     "volume": "1500 ml",
-	"ammo_type": "thrown",
+    "ammo_type": "thrown",
     "price": 0,
     "price_postapoc": 0,
-	"flags": [
+    "flags": [
       "TANGLE"
     ],
     "melee_damage": { "bash": 2 },
-	"thrown_damage": [ { "damage_type": "bash", "amount": 12 } ],
-	"relic_data": { "passive_effects": [ { "id": "can_throwing_ench_2" } ] }
+    "thrown_damage": [ { "damage_type": "bash", "amount": 12 } ],
+    "relic_data": { "passive_effects": [ { "id": "can_throwing_ench_2" } ] }
   },
   {
-    "id": "soda_armor_normal_hook",
+    "id": "EGO_soda_summon_armour_normal",
     "type": "SPELL",
-    "name": "[ז] EGO Soda - Summon armor",
-    "description": "Call forth the armor of a shrimp. The shrimp. WellCheers Shrimp.",
+    "name": "[ז] EGO Soda - Summon armour",
+    "description": "Call forth the armour of a shrimp. The shrimp. WellCheers Shrimp.",
     "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "soda_armor_hook_eoc_1",
+    "effect": "spawn_item",
+    "effect_str": "soda_armor_normal_item",
     "shape": "blast",
     "min_range": 0,
     "max_range": 0,
     "min_aoe": 0,
     "max_aoe": 0,
-    "min_duration": 20000,
-    "max_duration": 20000,
+    "min_duration": { "math": [ "2500 + (2300 * u_spell_level('EGO_soda'))" ] },
+    "max_duration": 24000,
+    "duration_increment": 2300,
     "base_casting_time": 80,
     "final_casting_time": 80,
     "spell_class": "EGO_Soda",
     "base_energy_cost": 750,
     "final_energy_cost": 750,
     "energy_source": "STAMINA",
+    "message": "The plating of a shrimp envelops you, though formed into the clothing of a shrimper.",
     "difficulty": 0,
     "max_level": 1,
     "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "NO_ARMS" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "soda_armor_hook_eoc_1",
-    "effect": [
-      { "u_cast_spell": { "id": "soda_armor_normal", "min_level": { "math": [ "u_spell_level('EGO_soda_stage_3')" ] } } },
-      {
-        "message": "The plating of a shrimp envelops you, though formed into the clothing of a dredger.",
-        "type": "bad"
-      }
-    ]
-  },
-  {
-    "id": "soda_armor_normal",
-    "type": "SPELL",
-    "name": "soda armor summon true",
-    "description": " technical desc",
-    "valid_targets": [ "self" ],
-    "flags": [ "SILENT" ],
-    "min_damage": 1,
-    "max_damage": 1,
-    "effect": "spawn_item",
-    "effect_str": "soda_armor_normal_item",
-    "shape": "blast",
-    "energy_source": "NONE",
-    "spell_class": "EGO_Soda",
-    "difficulty": 0,
-    "max_level": 10,
-    "base_casting_time": 80,
-    "base_energy_cost": 0,
-    "min_duration": 1000,
-    "max_duration": 24000,
-    "duration_increment": 2300
   },
   {
     "id": "soda_armor_normal_item",
@@ -805,185 +423,21 @@
     ]
   },
   {
-    "id": "EGO_soda_stage_4",
-    "type": "SPELL",
-    "name": "[ז] EGO Soda Invoke Bond - Stage 4",
-    "description": "Call your bond with Soda from the unfathomable depth of your entangling bond. However, any contact with an EGO takes a toll.",
-    "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "soda_stage_4_activation",
-    "shape": "blast",
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "min_duration": 600,
-    "max_duration": 6000,
-    "duration_increment": 600,
-    "base_casting_time": 100,
-    "final_casting_time": 10,
-    "casting_time_increment": -10,
-    "spell_class": "EGO_Soda",
-    "base_energy_cost": 100,
-    "final_energy_cost": 10,
-    "energy_increment": -10,
-    "energy_source": "STAMINA",
-    "difficulty": 4,
-    "max_level": 10,
-    "flags": [ "SILENT", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "soda_stage_4_activation",
-    "condition": { "not": { "u_has_effect": "EGO_CD" } },
-    "effect": [
-      {
-        "switch": { "math": [ "u_vitamin('emotion')" ] },
-        "cases": [
-          {
-            "case": 0,
-            "effect": [
-              { "math": [ "u_vitamin('emotion') -= 20" ] },
-              {
-                "u_cast_spell": { "id": "EGO_soda_stage_4_success", "min_level": { "math": [ "u_spell_level('EGO_soda_stage_4')" ] } }
-              },
-              { "u_message": "Your emotion manifests, bursting forwards in a rush of speed.", "type": "good" }
-            ]
-          },
-          {
-            "case": 50,
-            "effect": [
-              { "math": [ "u_vitamin('emotion') -= 50" ] },
-              {
-                "u_cast_spell": { "id": "EGO_soda_stage_4_success", "min_level": { "math": [ "u_spell_level('EGO_soda_stage_4')" ] } }
-              },
-              { "run_eocs": [ "soda_can_hook_eoc_3" ] },
-              { "run_eocs": [ "soda_armor_hook_eoc_3" ] },
-              {
-                "u_message": "Your strong emotions coalesce into a rush of speed, a can of Wellcheers forming in your hand, and the protective armour of a shrimp snapping around you.",
-                "type": "good"
-              }
-            ]
-          },
-          {
-            "case": 80,
-            "effect": [
-              { "math": [ "u_vitamin('emotion') -= 80" ] },
-              {
-                "u_cast_spell": { "id": "EGO_soda_stage_4_success", "min_level": { "math": [ "u_spell_level('EGO_soda_stage_4')" ] } }
-              },
-              { "run_eocs": [ "soda_can_hook_eoc_3" ] },
-              { "run_eocs": [ "soda_armor_hook_eoc_3" ] },
-              {
-                "u_message": "Your strong emotions coalesce into a rush of speed, a can of Wellcheers forming in your hand, and the protective armour of a shrimp snapping around you.",
-                "type": "mixed"
-              }
-            ]
-          }
-        ]
-      },
-      { "u_add_effect": "EGO_CD", "duration": "15 minutes" },
-      { "math": [ "u_health() -= 10" ] },
-      {
-        "u_add_morale": "ego_morale",
-        "bonus": -50,
-        "max_bonus": -400,
-        "duration": "70 minutes",
-        "decay_start": "22 minutes"
-      },
-      {
-        "run_eocs": "clear_spell_soda",
-        "time_in_future": { "math": [ "18 + (58.2 * u_spell_level('EGO_soda_stage_3'))" ] }
-      },
-	  { "run_eocs": "soda_chat_stage_1" }
-    ],
-    "false_effect": [
-      { "u_message": "EGO on cooldown!", "type": "bad" },
-      { "math": [ "u_health() -= 2" ] },
-      {
-        "u_add_morale": "ego_morale",
-        "bonus": -11,
-        "max_bonus": -400,
-        "duration": "70 minutes",
-        "decay_start": "22 minutes"
-      }
-    ]
-  },
-  {
-    "id": "EGO_soda_stage_4_success",
-    "type": "SPELL",
-    "name": "[ז] EGO Soda stage 4 activation",
-    "description": "EGO spell activation desc stage 4",
-    "valid_targets": [ "self" ],
-    "effect": "spawn_item",
-    "effect_str": "EGO_soda_stage_4_aura",
-    "shape": "blast",
-    "min_aoe": 0,
-    "max_aoe": 0,
-    "min_duration": 12000,
-    "max_duration": 36000,
-    "duration_increment": 2400,
-    "base_casting_time": 0,
-    "final_casting_time": 0,
-    "spell_class": "EGO_Soda",
-    "base_energy_cost": 0,
-    "final_energy_cost": 0,
-    "energy_source": "NONE",
-    "difficulty": 4,
-    "max_level": 10,
-    "flags": [ "SILENT" ]
-  },
-  {
-    "id": "EGO_soda_stage_4_aura",
-    "type": "ARMOR",
-    "name": "[ז] EGO Soda Awakened Aura",
-    "description": "You feel Soda's presence in your mind, alien, now that of a partner, you both act in a perfect synergy towards your aims. While the bond is active you sense you'll be significantly harder to knock down, better at dodging, and find it easier to throw items.",
-    "weight": "0 g",
-    "volume": "0 ml",
-    "material": [ "wind" ],
-    "symbol": "0",
-    "color": "white",
-    "flags": [ "ZERO_WEIGHT", "NO_TAKEOFF" ],
-    "relic_data": { "passive_effects": [ { "id": "EGO_soda_stage_4_ench" } ] }
-  },
-  {
-    "type": "enchantment",
-    "id": "EGO_soda_stage_4_ench",
-    "has": "WORN",
-    "condition": "ALWAYS",
-    "mutations": [ "EGO_soda_mutation_stage_4" ],
-    "values": [
-      { "value": "THROW_STR", "add": { "math": [ "2 + u_spell_level('EGO_soda_stage_4') * 1.5" ] } },
-      { "value": "SCENT_MASK", "add": 200 },
-      { "value": "DODGE_CHANCE", "add": { "math": [ "4 + u_spell_level('EGO_soda_stage_4') / 2" ] } },
-	    { "value": "BONUS_DODGE", "add": 1 },
-	    { "value": "KNOCKDOWN_RESIST", "add": 40 }
-    ]
-  },
-  {
-    "type": "mutation",
-    "id": "EGO_soda_mutation_stage_4",
-    "name": "[ז] EGO Soda manifestation",
-    "points": 0,
-    "description": "EGO Soda mutation desc",
-    "starting_trait": false,
-    "purifiable": false,
-    "valid": false,
-    "spells_learned": [ [ "soda_can_empower_hook", 1 ], [ "soda_armor_empower_hook", 1 ], [ "soda_net_empower_hook", 1 ], [ "soda_summon_wellcheers_hook", 1 ] ]
-  },
-  {
-    "id": "soda_can_empower_hook",
+    "id": "EGO_soda_summon_can_empower",
     "type": "SPELL",
     "name": "[ז] EGO Soda - Summon WellCheersBomb",
     "description": "Call forth the most delighful, refreshingly dangerous can of WellCheers within the known universe.",
     "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "soda_can_hook_eoc_3",
+    "effect": "spawn_item",
+    "effect_str": "soda_can_item_empower_act",
     "shape": "blast",
     "min_range": 0,
     "max_range": 0,
     "min_aoe": 0,
     "max_aoe": 0,
-    "min_duration": 200,
-    "max_duration": 200,
+    "min_duration": { "math": [ "6000 + (7200 * u_spell_level('EGO_soda'))" ] },
+    "max_duration": 78000,
+    "duration_increment": 7200,
     "base_casting_time": 35,
     "final_casting_time": 35,
     "spell_class": "EGO_Soda",
@@ -992,62 +446,7 @@
     "energy_source": "STAMINA",
     "difficulty": 0,
     "max_level": 1,
-    "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_LEGS", "NO_FAIL" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "soda_can_hook_eoc_3",
-    "effect": [
-      { "u_cast_spell": { "id": "soda_can_empower", "min_level": { "math": [ "u_spell_level('EGO_soda_stage_4')" ] } } },
-      {
-        "message": "Swiping your hand through the air, a cold metal touches your skin, the icy, refreshing touch of WellCheers.",
-        "type": "bad"
-      }
-    ]
-  },
-  {
-    "id": "soda_can_empower",
-    "type": "SPELL",
-    "name": "Soda can summon true",
-    "description": " technical desc",
-    "valid_targets": [ "self" ],
-    "flags": [ "SILENT" ],
-    "min_damage": 1,
-    "max_damage": 1,
-    "effect": "spawn_item",
-    "effect_str": "soda_can_item_empower",
-    "shape": "blast",
-    "energy_source": "NONE",
-    "spell_class": "EGO_Soda",
-    "difficulty": 0,
-    "max_level": 10,
-    "base_casting_time": 80,
-    "base_energy_cost": 0,
-    "min_duration": 6000,
-    "max_duration": 78000,
-    "duration_increment": 7200
-  },
-  {
-    "id": "soda_can_item_empower",
-    "type": "GENERIC",
-    "name": { "str": "<color_red>Can of WellCheers</color>" },
-    "description": "A can of delightfully refreshing WellCheers, but one you know not to taste - it is primed for destruction.",
-    "looks_like": "can_drink",
-    "symbol": "w",
-    "color": "light_gray",
-    "price": 0,
-    "price_postapoc": 0,
-    "melee_damage": { "bash": 2 },
-	"thrown_damage": [ { "damage_type": "bash", "amount": 10 } ],
-	"relic_data": { "passive_effects": [ { "id": "can_throwing_ench_2" } ] },
-	"use_action": {
-      "need_wielding": true,
-      "target": "soda_can_item_empower_act",
-      "msg": "You pull the tab on the soda can, it hisses audibly. You better throw it and run!",
-      "target_timer": "5 seconds",
-      "type": "transform"
-    },
-	"copy-from": "well_can"
+    "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_LEGS", "NO_FAIL", "PERMANENT" ]
   },
   {
     "id": "soda_can_item_empower_act",
@@ -1060,9 +459,13 @@
     "price": 0,
     "price_postapoc": 0,
     "melee_damage": { "bash": 2 },
-	"thrown_damage": [ { "damage_type": "cut", "amount": 10 } ],
-	"relic_data": { "passive_effects": [ { "id": "can_throwing_ench_3" } ] },
-	"countdown_action": {
+    "thrown_damage": [ { "damage_type": "cut", "amount": 10 } ],
+    "relic_data": { "passive_effects": [ { "id": "can_throwing_ench_3" } ] },
+    "countdown_interval": "5 seconds",
+    "flags": [
+      "SPAWN_ACTIVE"
+    ],
+    "countdown_action": {
       "type": "explosion",
       "fields_radius": 2,
       "do_flashbang": true,
@@ -1070,7 +473,7 @@
       "fields_min_intensity": 2,
       "fields_max_intensity": 3
     },
-	"copy-from": "well_can"
+    "copy-from": "well_can"
   },
   {
     "type": "enchantment",
@@ -1080,62 +483,31 @@
     "skills": [ { "value": "throw", "add": 3 } ]
   },
   {
-    "id": "soda_net_empower_hook",
+    "id": "EGO_soda_summon_net_empower",
     "type": "SPELL",
     "name": "[ז] EGO Soda - Summon Shrimping Net",
     "description": "Call forth a net with which to fuel the WellCheers need for shrimp.",
     "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "soda_net_hook_eoc_3",
+    "effect": "spawn_item",
+    "effect_str": "soda_net_empower_item",
     "shape": "blast",
     "min_range": 0,
     "max_range": 0,
     "min_aoe": 0,
     "max_aoe": 0,
-    "min_duration": 200,
-    "max_duration": 200,
+    "min_duration": { "math": [ "6000 + (7200 * u_spell_level('EGO_soda'))" ] },
+    "max_duration": 24000,
+    "duration_increment": 2300,
     "base_casting_time": 80,
     "final_casting_time": 80,
     "spell_class": "EGO_Soda",
     "base_energy_cost": 150,
     "final_energy_cost": 150,
     "energy_source": "STAMINA",
+    "message": "Woven cord patches itself together into your outstretched hand, until a pristine woven net is formed.",
     "difficulty": 0,
     "max_level": 1,
     "flags": [ "SILENT", "NO_FAIL", "NO_LEGS" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "soda_net_hook_eoc_3",
-    "effect": [
-      { "u_cast_spell": { "id": "soda_net_empower", "min_level": { "math": [ "u_spell_level('EGO_soda_stage_4')" ] } } },
-      {
-        "message": "Woven cord patches itself together into your outstretched hand, until a pristine woven net is formed.",
-        "type": "bad"
-      }
-    ]
-  },
-  {
-    "id": "soda_net_empower",
-    "type": "SPELL",
-    "name": "Soda net summon true",
-    "description": " technical desc",
-    "valid_targets": [ "self" ],
-    "flags": [ "SILENT" ],
-    "min_damage": 1,
-    "max_damage": 1,
-    "effect": "spawn_item",
-    "effect_str": "soda_net_empower_item",
-    "shape": "blast",
-    "energy_source": "NONE",
-    "spell_class": "EGO_Soda",
-    "difficulty": 0,
-    "max_level": 10,
-    "base_casting_time": 80,
-    "base_energy_cost": 0,
-    "min_duration": 1000,
-    "max_duration": 24000,
-    "duration_increment": 2300
   },
   {
     "id": "soda_net_empower_item",
@@ -1144,77 +516,46 @@
     "description": "A woven tangle of cord forming an incredibly light net, yet you can sense its desire to cling, wrap and tangle.",
     "looks_like": "net",
     "symbol": "n",
-	"material": "b_silk",
+    "material": "b_silk",
     "color": "light_gray",
-	"weight": "600 g",
+    "weight": "600 g",
     "volume": "1500 ml",
-	"ammo_type": "thrown",
+    "ammo_type": "thrown",
     "price": 0,
     "price_postapoc": 0,
-	"flags": [
+    "flags": [
       "TANGLE"
     ],
     "melee_damage": { "bash": 2 },
-	"thrown_damage": [ { "damage_type": "bash", "amount": 18 } ],
-	"relic_data": { "passive_effects": [ { "id": "can_throwing_ench_3" } ] }
+    "thrown_damage": [ { "damage_type": "bash", "amount": 18 } ],
+    "relic_data": { "passive_effects": [ { "id": "can_throwing_ench_3" } ] }
   },
   {
-    "id": "soda_armor_empower_hook",
+    "id": "EGO_soda_summon_armour_empower",
     "type": "SPELL",
-    "name": "[ז] EGO Soda - Summon armor",
-    "description": "Call forth the armor of a shrimp. The shrimp. WellCheers Shrimp.",
+    "name": "[ז] EGO Soda - Summon armour",
+    "description": "Call forth the armour of a shrimp. The shrimp. WellCheers Shrimp.",
     "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "soda_armor_hook_eoc_2",
+    "effect": "spawn_item",
+    "effect_str": "soda_armor_empowered_item",
     "shape": "blast",
     "min_range": 0,
     "max_range": 0,
     "min_aoe": 0,
     "max_aoe": 0,
-    "min_duration": 20000,
-    "max_duration": 20000,
+    "min_duration": { "math": [ "6000 + (7200 * u_spell_level('EGO_soda'))" ] },
+    "max_duration": 78000,
+    "duration_increment": 7200,
     "base_casting_time": 80,
     "final_casting_time": 80,
     "spell_class": "EGO_Soda",
     "base_energy_cost": 250,
     "final_energy_cost": 250,
     "energy_source": "STAMINA",
+    "message": "The plating of a shrimp envelops you, though formed into the clothing of a dredger.",
     "difficulty": 0,
     "max_level": 1,
     "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "NO_ARMS" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "soda_armor_hook_eoc_2",
-    "effect": [
-      { "u_cast_spell": { "id": "soda_armor_empowered", "min_level": { "math": [ "u_spell_level('EGO_soda_stage_4')" ] } } },
-      {
-        "message": "The plating of a shrimp envelops you, though formed into the clothing of a dredger.",
-        "type": "bad"
-      }
-    ]
-  },
-  {
-    "id": "soda_armor_empowered",
-    "type": "SPELL",
-    "name": "soda armor summon true",
-    "description": " technical desc",
-    "valid_targets": [ "self" ],
-    "flags": [ "SILENT" ],
-    "min_damage": 1,
-    "max_damage": 1,
-    "effect": "spawn_item",
-    "effect_str": "soda_armor_empowered_item",
-    "shape": "blast",
-    "energy_source": "NONE",
-    "spell_class": "EGO_Soda",
-    "difficulty": 0,
-    "max_level": 10,
-    "base_casting_time": 80,
-    "base_energy_cost": 0,
-    "min_duration": 6000,
-    "max_duration": 78000,
-    "duration_increment": 7200
   },
   {
     "id": "soda_armor_empowered_item",
@@ -1241,7 +582,7 @@
     ]
   },
   {
-    "id": "soda_summon_wellcheers_hook",
+    "id": "EGO_soda_summon_wellcheers",
     "type": "SPELL",
     "name": "[ז] EGO Soda - Summon Can of WellCheers",
     "description": "Manifest an actual can of WellCheers that doesn't, you know, explode. It is ephemeral however, and will not last long if not consumed. Manifesting such a thing from the aether is very taxing in the long term.",
@@ -1305,9 +646,9 @@
   {
     "type": "effect_on_condition",
     "id": "soda_chat_stage_1",
-	"recurrence": [ "5 turns", "40 turns" ],
+    "recurrence": [ "5 turns", "40 turns" ],
     "condition": { "u_has_trait": "EGO_soda_mutation_stage_1" },
-	"deactivate_condition": { "not": { "u_has_trait": "EGO_soda_mutation_stage_1" } },
+    "deactivate_condition": { "not": { "u_has_trait": "EGO_soda_mutation_stage_1" } },
     "effect": [ {
         "set_string_var": [
           "Prawn.",
@@ -1316,25 +657,27 @@
         ],
         "target_var": { "u_val": "quote" }
       },
-      { "message": "<u_val:quote>", "type": "mixed" } ]
+      { "message": "<u_val:quote>", "type": "mixed" } 
+    ]
   },
   {
     "type": "effect_on_condition",
     "id": "soda_chat_stage_2",
-	"recurrence": [ "10 turns", "80 turns" ],
+    "recurrence": [ "10 turns", "80 turns" ],
     "condition": { "u_has_trait": "EGO_soda_mutation_stage_2" },
-	"deactivate_condition": { "not": { "u_has_trait": "EGO_soda_mutation_stage_2" } },
+    "deactivate_condition": { "not": { "u_has_trait": "EGO_soda_mutation_stage_2" } },
     "effect": [ {
         "set_string_var": [
           "Prawn. Prawn.",
           "The delicious taste of WellCheers!.",
           "Some humans just get unlucky..",
           "Our Mascot, Our Mascot!",
-		  "Find the Cans, open them!"
+          "Find the Cans, open them!"
         ],
         "target_var": { "u_val": "quote" }
       },
-      { "message": "<u_val:quote>", "type": "mixed" } ]
+      { "message": "<u_val:quote>", "type": "mixed" } 
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -1349,12 +692,13 @@
           "Everyone should know our name!",
           "Stinky zombies can't know the delight of WellCheers.",
           "You're squishy! Squishy, right?",
-		  "We should drag someone off, when they're asleep...",
+          "We should drag someone off, when they're asleep...",
           "Did you hear that?"
         ],
         "target_var": { "u_val": "quote" }
       },
-      { "message": "<u_val:quote>", "type": "mixed" } ]
+      { "message": "<u_val:quote>", "type": "mixed" } 
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -1373,6 +717,21 @@
         ],
         "target_var": { "u_val": "quote" }
       },
-      { "message": "<u_val:quote>", "type": "mixed" } ]
+      { "message": "<u_val:quote>", "type": "mixed" } 
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "clear_spells_soda",
+    "effect": [
+      { "math": [ "u_spell_level('EGO_soda_summon_can_weak')", "=", "-1" ] },
+      { "math": [ "u_spell_level('EGO_soda_summon_can_normal')", "=", "-1" ] },
+      { "math": [ "u_spell_level('EGO_soda_summon_armour_normal')", "=", "-1" ] },
+      { "math": [ "u_spell_level('EGO_soda_summon_net_normal')", "=", "-1" ] },
+      { "math": [ "u_spell_level('EGO_soda_summon_wellcheers')", "=", "-1" ] },
+      { "math": [ "u_spell_level('EGO_soda_summon_can_empower')", "=", "-1" ] },
+      { "math": [ "u_spell_level('EGO_soda_summon_armour_empower')", "=", "-1" ] },
+      { "math": [ "u_spell_level('EGO_soda_summon_net_empower')", "=", "-1" ] }
+    ]
   }
 ]

--- a/AnomalousThings/Wellcheers/Soda/EGO Soda.json
+++ b/AnomalousThings/Wellcheers/Soda/EGO Soda.json
@@ -20,9 +20,8 @@
     "shape": "blast",
     "min_aoe": 0,
     "max_aoe": 0,
-    "min_duration": 600,
-    "max_duration": 24000,
-    "duration_increment": 600,
+    "min_duration": { "math": ["600 + (400 * (u_spell_level('EGO_soda')^2))"] },
+    "duration_increment": 0,
     "base_casting_time": 200,
     "final_casting_time": 25,
     "casting_time_increment": -5,
@@ -40,7 +39,7 @@
     "id": "soda_activation",
     "condition": { "not": { "u_has_effect": "EGO_CD" } },
     "effect": [
-      { "u_add_effect": "EGO_CD", "duration": "5 minutes" },
+      { "u_add_effect": "EGO_CD", "duration": { "math": ["300 + (4 * (u_spell_level('EGO_soda')^2))"] } },
       { "math": [ "u_vitamin('emotion') -= 20" ] },
       {
         "u_cast_spell": { "id": "EGO_soda_success", "hit_self": true, "min_level": { "math": [ "u_spell_level('EGO_soda')" ] } }
@@ -55,9 +54,9 @@
       },
       {
         "run_eocs": "clear_spells_soda",
-        "time_in_future": { "math": ["600 + 600 * u_spell_level('EGO_soda')"] }
+        "time_in_future": { "math": ["6 + (4 * (u_spell_level('EGO_soda')^2))"] }
       },
-      { "run_eocs": "soda_chat_stage_1" }
+      { "run_eocs": "soda_chat" }
     ],
     "false_effect": [
       { "u_message": "EGO on cooldown!", "type": "bad" },
@@ -82,9 +81,7 @@
     "shape": "blast",
     "min_aoe": 0,
     "max_aoe": 0,
-    "min_duration": 600,
-    "max_duration": 18000,
-    "duration_increment": 600,
+    "min_duration": { "math": ["600 + (400 * (u_spell_level('EGO_soda')^2))"] },
     "base_casting_time": 0,
     "final_casting_time": 0,
     "spell_class": "EGO_Soda",
@@ -99,7 +96,7 @@
     "id": "EGO_soda_aura",
     "type": "ARMOR",
     "name": "[ז] EGO Soda Aura",
-    "description": "You feel Soda's presence in your mind, alien, twisting and writhing, yet granting you power beyond any mere mortal. While the bond is active you sense you'll be slightly harder to knock down, better at dodging, and find it easier to throw items.",
+    "description": "You feel Soda's presence in your mind, alien, twisting and writhing, yet granting you power beyond any mere mortal. While the bond is active you sense you'll be harder to knock down, better at dodging, and find it easier to throw items.",
     "weight": "0 g",
     "volume": "0 ml",
     "material": [ "wind" ],
@@ -602,7 +599,7 @@
     "base_energy_cost": 250,
     "final_energy_cost": 250,
     "energy_source": "STAMINA",
-    "difficulty": 4,
+    "difficulty": 3,
     "max_level": 1,
     "flags": [ "SILENT", "NO_LEGS", "NO_ARMS" ]
   },
@@ -614,7 +611,7 @@
 	  { "math": [ "u_health() -= 5" ] },
       {
         "message": "A delightfully refreshing beverage materialises into your hand. You feel.. A little more weary from the effort.",
-        "type": "good"
+        "type": "mixed"
       }
     ]
   },
@@ -645,93 +642,92 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "soda_chat_stage_1",
-    "recurrence": [ "5 turns", "40 turns" ],
-    "condition": { "u_has_trait": "EGO_soda_mutation_stage_1" },
-    "deactivate_condition": { "not": { "u_has_trait": "EGO_soda_mutation_stage_1" } },
-    "effect": [ {
-        "set_string_var": [
-          "Prawn.",
-          "Prawn, Prawn.",
-          "PRAWN, PRAWN. Prawn."
-        ],
-        "target_var": { "u_val": "quote" }
-      },
-      { "message": "<u_val:quote>", "type": "mixed" } 
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "soda_chat_stage_2",
+    "id": "soda_chat",
     "recurrence": [ "10 turns", "80 turns" ],
     "condition": { "u_has_trait": "EGO_soda_mutation_stage_2" },
     "deactivate_condition": { "not": { "u_has_trait": "EGO_soda_mutation_stage_2" } },
-    "effect": [ {
-        "set_string_var": [
-          "Prawn. Prawn.",
-          "The delicious taste of WellCheers!.",
-          "Some humans just get unlucky..",
-          "Our Mascot, Our Mascot!",
-          "Find the Cans, open them!"
-        ],
-        "target_var": { "u_val": "quote" }
+    "effect": [ 
+      { 
+        "switch": { "math": [ "u_spell_level('EGO_soda')" ] },
+        "cases": [
+          {
+            "case": 0,
+            "effect": [
+              {
+                "set_string_var": [
+                  "Prawn.",
+                  "Prawn, Prawn.",
+                  "PRAWN, PRAWN. Prawn."
+                ],
+                "target_var": { "u_val": "quote" }
+              }
+            ]
+          },
+          {
+            "case": 10,
+            "effect": [ 
+              {
+                "set_string_var": [
+                  "Prawn. Prawn.",
+                  "The delicious taste of WellCheers!.",
+                  "Some humans just get unlucky..",
+                  "Our Mascot, Our Mascot!",
+                  "Find the Cans, open them!"
+                ],
+                "target_var": { "u_val": "quote" }
+              }
+            ]
+          },
+          {
+            "case": 20,
+            "effect": [ 
+              {
+                "set_string_var": [
+                  "We should show the world our flavour!",
+                  "WellCheers, the taste you'll never forget!",
+                  "Everyone should know our name!",
+                  "Stinky zombies can't know the delight of WellCheers.",
+                  "You're squishy! Squishy, right?",
+                  "We should drag someone off, when they're asleep...",
+                  "Did you hear that?"
+                ],
+                "target_var": { "u_val": "quote" }
+              }
+            ]
+          },
+          {
+            "case": 25,
+            "effect": [ 
+              {
+                "set_string_var": [
+                  "Prawn is the best flavour, you agree, right? Right?",
+                  "All our flavours, and we're the best!",
+                  "We should drag someone off, when they're asleep...",
+                  "We'll give you the strength to show the world how amazing we are!",
+                  "Hey, hey, listen...!",
+                  "Fizz goes the can, byebye goes the bad...~"
+                ],
+                "target_var": { "u_val": "quote" }
+              }
+            ]
+          }
+        ]
       },
-      { "message": "<u_val:quote>", "type": "mixed" } 
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "soda_chat_stage_3",
-	"recurrence": [ "20 turns", "160 turns" ],
-    "condition": { "u_has_trait": "EGO_soda_mutation_stage_3" },
-	"deactivate_condition": { "not": { "u_has_trait": "EGO_soda_mutation_stage_3" } },
-    "effect": [ {
-        "set_string_var": [
-          "We should show the world our flavour!",
-          "WellCheers, the taste you'll never forget!",
-          "Everyone should know our name!",
-          "Stinky zombies can't know the delight of WellCheers.",
-          "You're squishy! Squishy, right?",
-          "We should drag someone off, when they're asleep...",
-          "Did you hear that?"
-        ],
-        "target_var": { "u_val": "quote" }
-      },
-      { "message": "<u_val:quote>", "type": "mixed" } 
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "soda_chat_stage_4",
-	"recurrence": [ "40 turns", "320 turns" ],
-    "condition": { "u_has_trait": "EGO_soda_mutation_stage_4" },
-	"deactivate_condition": { "not": { "u_has_trait": "EGO_soda_mutation_stage_4" } },
-    "effect": [ {
-        "set_string_var": [
-          "Prawn is the best flavour, you agree, right? Right?",
-          "All our flavours, and we're the best!",
-          "We should drag someone off, when they're asleep...",
-          "We'll give you the strength to show the world how amazing we are!",
-          "Hey, hey, listen...!",
-          "Fizz goes the can, byebye goes the bad...~"
-        ],
-        "target_var": { "u_val": "quote" }
-      },
-      { "message": "<u_val:quote>", "type": "mixed" } 
+      { "message": "<color_light_red>\"<u_val:quote>\"</color>", "type": "mixed" } 
     ]
   },
   {
     "type": "effect_on_condition",
     "id": "clear_spells_soda",
     "effect": [
-      { "math": [ "u_spell_level('EGO_soda_summon_can_weak')", "=", "-1" ] },
-      { "math": [ "u_spell_level('EGO_soda_summon_can_normal')", "=", "-1" ] },
-      { "math": [ "u_spell_level('EGO_soda_summon_armour_normal')", "=", "-1" ] },
-      { "math": [ "u_spell_level('EGO_soda_summon_net_normal')", "=", "-1" ] },
-      { "math": [ "u_spell_level('EGO_soda_summon_wellcheers')", "=", "-1" ] },
-      { "math": [ "u_spell_level('EGO_soda_summon_can_empower')", "=", "-1" ] },
-      { "math": [ "u_spell_level('EGO_soda_summon_armour_empower')", "=", "-1" ] },
-      { "math": [ "u_spell_level('EGO_soda_summon_net_empower')", "=", "-1" ] }
+      { "math": [ "u_spell_level('EGO_soda_summon_can_weak') = -1" ] },
+      { "math": [ "u_spell_level('EGO_soda_summon_can_normal') = -1" ] },
+      { "math": [ "u_spell_level('EGO_soda_summon_armour_normal') = -1" ] },
+      { "math": [ "u_spell_level('EGO_soda_summon_net_normal') = -1" ] },
+      { "math": [ "u_spell_level('EGO_soda_summon_wellcheers') = -1" ] },
+      { "math": [ "u_spell_level('EGO_soda_summon_can_empower') = -1" ] },
+      { "math": [ "u_spell_level('EGO_soda_summon_armour_empower') = -1" ] },
+      { "math": [ "u_spell_level('EGO_soda_summon_net_empower') = -1" ] }
     ]
   }
 ]

--- a/EoCs.json
+++ b/EoCs.json
@@ -172,7 +172,7 @@
       },
       { 
         "if": { "math": [ "u_spell_level('EGO_soda') > -1" ] },
-        "then": { "math": [ "u_spell_exp('EGO_soda') += 200" ] } 
+        "then": [ { "math": [ "u_spell_exp('EGO_soda') += 200" ] }, { "u_message": "You feel Soda resonate, dancing in your subconcious as you drink down more glorious WellCheers."} ]
       }
     ]
   },
@@ -188,7 +188,7 @@
       },
       { 
         "if": { "math": [ "u_spell_level('EGO_soda') > -1" ] },
-        "then": { "math": [ "u_spell_exp('EGO_soda') += 200" ] } 
+        "then": [ { "math": [ "u_spell_exp('EGO_soda') += 200" ] }, { "u_message": "You feel Soda resonate, dancing in your subconcious as you drink down more glorious WellCheers."} ]
       }
     ]
   },
@@ -204,7 +204,7 @@
       },
       { 
         "if": { "math": [ "u_spell_level('EGO_soda') > -1" ] },
-        "then": { "math": [ "u_spell_exp('EGO_soda') += 400" ] } 
+        "then": [ { "math": [ "u_spell_exp('EGO_soda') += 400" ] }, { "u_message": "You feel Soda resonate, dancing in your subconcious as you drink down more glorious WellCheers."} ]
       }
     ]
   },

--- a/EoCs.json
+++ b/EoCs.json
@@ -133,72 +133,21 @@
     "type": "effect_on_condition",
     "id": "soda_ego_evolve",
     "effect": [
-      {
-		"if": {
-          "and": [
-            { "math": [ "u_spell_level('EGO_soda_stage_1')", "==", "-1" ] },
-            { "math": [ "u_spell_level('EGO_soda_stage_2')", "==", "-1" ] },
-            { "math": [ "u_spell_level('EGO_soda_stage_3')", "==", "-1" ] },
-            { "math": [ "u_spell_level('EGO_soda_stage_4')", "==", "-1" ] }
-          ]
-        },
-		"then": [
-			{ "math": [ "u_spell_level('EGO_soda_stage_1')", "=", "1" ] },
-			{
-			  "u_message": "You feel the drink connect to you.. Like really connect, an absolute understanding of prawn-based soda. An energy thrumming through your body, expanding, changing, an ego that's not entirely your own settling within the depths of your mind. You could call on it, if you really wished to. Somehow, in the flicker of your mind, you recognise that energy. Soda.",
-			  "popup": true
-			}
-		],
-		"else": {
-			"if": {
-			  "and": [
-				{ "math": [ "u_spell_level('EGO_soda_stage_1')", "<", "10" ] },
-				{ "math": [ "u_spell_level('EGO_soda_stage_2')", "==", "-1" ] },
-				{ "math": [ "u_spell_level('EGO_soda_stage_3')", "==", "-1" ] },
-				{ "math": [ "u_spell_level('EGO_soda_stage_4')", "==", "-1" ] }
-			  ]
-			},
-			"then": [
-			  { "math": [ "u_spell_level('EGO_soda_stage_1')", "+=", "1" ] },
-			  {
-				"u_message": "The delighful taste of shrimp floods you, burning a chorus of flavour in your mind. You feel your bond with Soda strengthening."
-			  }
-			],
-			"else": {
-			  "if": {
-				"and": [
-				  { "math": [ "u_spell_level('EGO_soda_stage_2')", "<", "10" ] },
-				  { "math": [ "u_spell_level('EGO_soda_stage_3')", "==", "-1" ] },
-				  { "math": [ "u_spell_level('EGO_soda_stage_4')", "==", "-1" ] }
-				]
-			  },
-			  "then": [
-				{ "math": [ "u_spell_level('EGO_soda_stage_2')", "+=", "1" ] },
-				{ "u_message": "You almost panic as the tidal wave of shrimp hits you, thoughts arising in your mind - more Soda's than yours." },
-				{ "math": [ "u_spell_level('EGO_soda_stage_1')", "=", "-1" ] }
-			  ],
-			  "else": {
-				"if": {
-				  "and": [
-					{ "math": [ "u_spell_level('EGO_soda_stage_3')", "<", "10" ] },
-					{ "math": [ "u_spell_level('EGO_soda_stage_4')", "==", "-1" ] }
-				  ]
-				},
-				"then": [
-				  { "math": [ "u_spell_level('EGO_soda_stage_3')", "+=", "1" ] },
-				  {
-					"u_message": "The thoughts of Soda ring in your head as the prawn dances across your tongue, a dangerous little dance."
-				  },
-				  { "math": [ "u_spell_level('EGO_soda_stage_2')", "=", "-1" ] }
-				],
-				"else": [
-				  { "math": [ "u_spell_level('EGO_soda_stage_4')", "+=", "1" ] },
-				  { "u_message": "You feel your understanding of Soda deepen into an unfathomable taste, something about the vastness feels.. Wrong." },
-				  { "math": [ "u_spell_level('EGO_soda_stage_3')", "=", "-1" ] }
-				]
-			  }
-			}
-		}
+      { 
+        "if": { "math": [ "u_spell_level('EGO_soda')", "==", "-1" ] },
+        "then": [
+          { "math": [ "u_spell_level('EGO_soda')", "=", "1" ] },
+          {
+            "u_message": "You feel the drink connect to you.. Like really connect, an absolute understanding of prawn-based soda. An energy thrumming through your body, expanding, changing, an ego that's not entirely your own settling within the depths of your mind. You could call on it, if you really wished to. Somehow, in the flicker of your mind, you recognise that energy. Soda.",
+            "popup": true
+          }
+        ],
+        "else": [ 
+          { "math": [ "u_spell_level('EGO_soda')", "+=", "1" ] },
+          {
+            "u_message": "The delighful taste of shrimp floods you, burning a chorus of flavour in your mind. You feel your bond with Soda strengthening."
+          }
+        ]
       }
     ]
   },
@@ -214,32 +163,50 @@
   {
     "type": "effect_on_condition",
     "id": "well_random",
-    "effect": {
-      "weighted_list_eocs": [
+    "effect": [
+      { 
+        "weighted_list_eocs": [
         [ { "id": "well_hook_eff1", "effect": { "run_eocs": "well_effect" } }, 18 ],
         [ { "id": "well_hook_abd1", "effect": { "run_eocs": "well_abduct" } }, 1 ]
-      ]
-    }
+      ] 
+      },
+      { 
+        "if": { "math": [ "u_spell_level('EGO_soda') > -1" ] },
+        "then": { "math": [ "u_spell_exp('EGO_soda') += 200" ] } 
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
     "id": "wellcherry_random",
-    "effect": {
-      "weighted_list_eocs": [
+    "effect": [
+      { 
+        "weighted_list_eocs": [
         [ { "id": "well_hook_eff2", "effect": { "run_eocs": "wellcherry_effect" } }, 18 ],
         [ { "id": "well_hook_abd2", "effect": { "run_eocs": "well_abduct" } }, 1 ]
-      ]
-    }
+      ] 
+      },
+      { 
+        "if": { "math": [ "u_spell_level('EGO_soda') > -1" ] },
+        "then": { "math": [ "u_spell_exp('EGO_soda') += 200" ] } 
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
     "id": "wellgrape_random",
-    "effect": {
-      "weighted_list_eocs": [
+    "effect": [
+      { 
+        "weighted_list_eocs": [
         [ { "id": "well_hook_eff3", "effect": { "run_eocs": "wellgrape_effect" } }, 18 ],
         [ { "id": "well_hook_abd3", "effect": { "run_eocs": "well_abduct" } }, 1 ]
-      ]
-    }
+      ] 
+      },
+      { 
+        "if": { "math": [ "u_spell_level('EGO_soda') > -1" ] },
+        "then": { "math": [ "u_spell_exp('EGO_soda') += 400" ] } 
+      }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/Items/Item_group.json
+++ b/Items/Item_group.json
@@ -93,7 +93,7 @@
             { "item": "wellcheers", "prob": 50 },
             { "item": "cherry_wellcheers", "prob": 50 },
             { "item": "grape_wellcheers", "prob": 50 },
-            { "item": "zweiflyer_item", "prob": 10 }
+            { "item": "zweiflyer_item", "prob": 40 }
           ]
         }
       ]
@@ -123,7 +123,7 @@
     "id": "trash",
     "type": "item_group",
     "copy-from": "trash",
-    "extend": { "items": [ { "item": "zweiflyer_item", "prob": 8 } ] }
+    "extend": { "items": [ { "item": "zweiflyer_item", "prob": 12 } ] }
   },
   {
     "id": "shrimp_drop",

--- a/damage_types.json
+++ b/damage_types.json
@@ -101,7 +101,7 @@
     "id": "effect_gloom_res",
     "name": [ "Gloom Resistance" ],
     "desc": [ "" ],
-	"show_in_info": true,
+    "show_in_info": false,
     "rating": "good",
     "enchantments": [
       {


### PR DESCRIPTION
Changes:
- Refactored Soda to work via a single Aura spell
- Added in an xp gain to drinking wellcheers to Soda


Fixes:
- Increased spawnrate of Zwei Flyer
- Made Gloom Resistance invisible to the player