### PR TITLE
Fixes, new terrain for train test

### DIFF
--- a/AnomalousThings/Birdo/Items.json
+++ b/AnomalousThings/Birdo/Items.json
@@ -50,8 +50,9 @@
     "symbol": "[",
     "color": "white",
     "looks_like": "ego_teth",
+    "repairs_with": "punishing_feather",
     "relic_data": { "passive_effects": [ { "id": "beak_suit_1" }, { "id": "beak_suit_2" }, { "id": "beak_suit_3" } ] },
-    "flags": [ "NORMAL", "VARSIZE", "STURDY", "PADDED", "BLOCK_WHILE_WORN", "ONLY_ONE", "NO_REPAIR", "TRADER_AVOID", "NO_SALVAGE" ],
+    "flags": [ "NORMAL", "VARSIZE", "STURDY", "PADDED", "BLOCK_WHILE_WORN", "ONLY_ONE", "TRADER_AVOID", "NO_SALVAGE" ],
     "armor": [
       {
         "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],

--- a/AnomalousThings/BookThatDontBelongToYou/Owner/EGO spez.json
+++ b/AnomalousThings/BookThatDontBelongToYou/Owner/EGO spez.json
@@ -281,7 +281,7 @@
     "message": "*A clot of flame appears in your hand, forms a sword and solidifies into a solid form*",
     "difficulty": 0,
     "max_level": 1,
-    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS" ]
+    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "NO_HANDS" ]
   },
   {
     "id": "92_sword_weak_item",
@@ -355,7 +355,7 @@
     "min_duration": { "math": [ "1000 + 2300 * u_spell_level('EGO_92_invoke')" ] },
     "max_duration": 24000,
     "message": "A clot of flame appears in your hand, forms a sword and solidifies into a solid form.",
-    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS" ]
+    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "NO_HANDS" ]
   },
   {
     "id": "92_sword_item",
@@ -444,7 +444,7 @@
     "difficulty": 0,
     "max_level": 1,
     "message": "The flame enveloped you, but it does not burn, after which the armor of the Prophet materialized on you.",
-    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "NO_ARMS" ]
+    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "NO_ARMS", "NO_HANDS" ]
   },
   {
     "id": "92_armor_normal_item",
@@ -462,7 +462,7 @@
     "warmth": 20,
     "material_thickness": 2.2,
     "environmental_protection": 15,
-    "flags": [ "AURA", "WATER_FRIENDLY", "PROPHET_RESIST" ],
+    "flags": [ "AURA", "WATER_FRIENDLY", "PROPHET_RESIST", "INTEGRATED" ],
     "armor": [
       {
         "coverage": 100,
@@ -914,7 +914,7 @@
     "difficulty": 0,
     "max_level": 1,
     "message": "A clot of flame appears in your hand, forms a sword and solidifies into a solid form.",
-    "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_LEGS", "NO_FAIL" ]
+    "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_LEGS", "NO_FAIL", "NO_HANDS" ]
   },
   {
     "id": "92_sword_item_empower",
@@ -1106,7 +1106,7 @@
     "looks_like": "ego_teth",
     "material_thickness": 4,
     "environmental_protection": 20,
-    "flags": [ "AURA", "WATER_FRIENDLY" ],
+    "flags": [ "AURA", "WATER_FRIENDLY", "INTEGRATED" ],
     "armor": [
       {
         "coverage": 100,

--- a/AnomalousThings/BookThatDontBelongToYou/Owner/EGO spez.json
+++ b/AnomalousThings/BookThatDontBelongToYou/Owner/EGO spez.json
@@ -462,7 +462,7 @@
     "warmth": 20,
     "material_thickness": 2.2,
     "environmental_protection": 15,
-    "flags": [ "AURA", "WATER_FRIENDLY", "PROPHET_RESIST", "INTEGRATED" ],
+    "flags": [ "AURA", "WATER_FRIENDLY", "PROPHET_RESIST", "UNRESTRICTED" ],
     "armor": [
       {
         "coverage": 100,
@@ -1106,7 +1106,7 @@
     "looks_like": "ego_teth",
     "material_thickness": 4,
     "environmental_protection": 20,
-    "flags": [ "AURA", "WATER_FRIENDLY", "INTEGRATED" ],
+    "flags": [ "AURA", "WATER_FRIENDLY", "UNRESTRICTED" ],
     "armor": [
       {
         "coverage": 100,

--- a/AnomalousThings/Ordeals/Green Dawn/RustyRobotsRecipies.json
+++ b/AnomalousThings/Ordeals/Green Dawn/RustyRobotsRecipies.json
@@ -6,7 +6,7 @@
     "skill_used": "fabrication",
     "difficulty": 3,
     "time": "12 m",
-    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WELD", "level": 1 }, { "id": "HACKSAW", "level": 1 } ],
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WELD", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "scrapmetal_item", 4 ] ], [ [ "casepiece_item", 1 ] ], [ [ "blackmetalwire_item", 1 ] ] ]
   },
   {
@@ -16,7 +16,7 @@
     "skill_used": "fabrication",
     "difficulty": 3,
     "time": "12 m",
-    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WELD", "level": 2 }, { "id": "HACKSAW", "level": 1 } ],
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WELD", "level": 2 }, { "id": "SAW_M", "level": 1 } ],
     "components": [
       [ [ "scrapmetal_item", 7 ] ],
       [ [ "casepiece_item", 1 ] ],
@@ -41,7 +41,7 @@
     "qualities": [
       { "id": "SCREW", "level": 1 },
       { "id": "WELD", "level": 1 },
-      { "id": "HACKSAW", "level": 1 },
+      { "id": "SAW_M", "level": 1 },
       { "id": "HAMMER", "level": 2 }
     ],
     "proficiencies": [
@@ -78,7 +78,7 @@
     "qualities": [
       { "id": "SCREW", "level": 1 },
       { "id": "WELD", "level": 1 },
-      { "id": "HACKSAW", "level": 1 },
+      { "id": "SAW_M", "level": 1 },
       { "id": "HAMMER", "level": 2 }
     ],
     "proficiencies": [
@@ -115,7 +115,7 @@
     "qualities": [
       { "id": "SCREW", "level": 1 },
       { "id": "WELD", "level": 1 },
-      { "id": "HACKSAW", "level": 1 },
+      { "id": "SAW_M", "level": 1 },
       { "id": "HAMMER", "level": 2 }
     ],
     "proficiencies": [
@@ -152,7 +152,7 @@
     "qualities": [
       { "id": "SCREW", "level": 1 },
       { "id": "WELD", "level": 1 },
-      { "id": "HACKSAW", "level": 1 },
+      { "id": "SAW_M", "level": 1 },
       { "id": "HAMMER", "level": 2 }
     ],
     "proficiencies": [
@@ -189,7 +189,7 @@
     "qualities": [
       { "id": "SCREW", "level": 1 },
       { "id": "WELD", "level": 1 },
-      { "id": "HACKSAW", "level": 1 },
+      { "id": "SAW_M", "level": 1 },
       { "id": "HAMMER", "level": 2 }
     ],
     "proficiencies": [
@@ -226,7 +226,7 @@
     "qualities": [
       { "id": "SCREW", "level": 1 },
       { "id": "WELD", "level": 1 },
-      { "id": "HACKSAW", "level": 1 },
+      { "id": "SAW_M", "level": 1 },
       { "id": "HAMMER", "level": 2 }
     ],
     "proficiencies": [

--- a/AnomalousThings/Wellcheers/Egocheers.json
+++ b/AnomalousThings/Wellcheers/Egocheers.json
@@ -11,8 +11,9 @@
     "material": [ "l_steel", "b_polymer", "l_cotton" ],
     "symbol": "[",
     "color": "blue",
+    "repairs_with": "wellcherry_can",
     "relic_data": { "passive_effects": [ { "id": "soda_suit_1" }, { "id": "soda_suit_2" }, { "id": "soda_suit_3" } ] },
-    "flags": [ "NORMAL", "VARSIZE", "STURDY", "PADDED", "BLOCK_WHILE_WORN", "ONLY_ONE", "NO_REPAIR", "TRADER_AVOID", "NO_SALVAGE" ],
+    "flags": [ "NORMAL", "VARSIZE", "STURDY", "PADDED", "BLOCK_WHILE_WORN", "ONLY_ONE", "TRADER_AVOID", "NO_SALVAGE" ],
     "armor": [
       {
         "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],

--- a/AnomalousThings/Wellcheers/Soda/EGO Soda.json
+++ b/AnomalousThings/Wellcheers/Soda/EGO Soda.json
@@ -411,7 +411,7 @@
     "warmth": 5,
     "material_thickness": 1.6,
     "environmental_protection": 5,
-    "flags": [ "AURA", "WATER_FRIENDLY", "INTEGRATED" ],
+    "flags": [ "AURA", "WATER_FRIENDLY", "UNRESTRICTED" ],
     "armor": [
       {
         "coverage": 100,
@@ -570,7 +570,7 @@
     "warmth": 5,
     "material_thickness": 2.1,
     "environmental_protection": 10,
-    "flags": [ "AURA", "WATER_FRIENDLY" ],
+    "flags": [ "AURA", "WATER_FRIENDLY", "UNRESTRICTED" ],
     "armor": [
       {
         "coverage": 100,

--- a/AnomalousThings/Wellcheers/Soda/EGO Soda.json
+++ b/AnomalousThings/Wellcheers/Soda/EGO Soda.json
@@ -225,7 +225,7 @@
     "message": "Swiping your hand through the air, a cold metal touches your skin, the icy, refreshing touch of WellCheers.",
     "difficulty": 0,
     "max_level": 1,
-    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "PERMANENT" ]
+    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "PERMANENT", "NO_HANDS" ]
   },
   {
     "id": "soda_can_weak_item_act",
@@ -285,7 +285,7 @@
     "message": "Swiping your hand through the air, a cold metal touches your skin, the icy, refreshing touch of WellCheers.",
     "difficulty": 0,
     "max_level": 1,
-    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "PERMANENT" ]
+    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "PERMANENT", "NO_HANDS" ]
   },
   {
     "id": "soda_can_item_act",
@@ -345,7 +345,7 @@
     "message": "Woven cord patches itself together into your outstretched hand, until a pristine woven net is formed.",
     "difficulty": 0,
     "max_level": 1,
-    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS" ]
+    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "NO_HANDS" ]
   },
   {
     "id": "soda_net_item",
@@ -371,7 +371,7 @@
   {
     "id": "EGO_soda_summon_armour_normal",
     "type": "SPELL",
-    "name": "[ז] EGO Soda - Summon armour",
+    "name": "[ז] EGO Soda - Summon Armour",
     "description": "Call forth the armour of a shrimp. The shrimp. WellCheers Shrimp.",
     "valid_targets": [ "self" ],
     "effect": "spawn_item",
@@ -393,7 +393,7 @@
     "message": "The plating of a shrimp envelops you, though formed into the clothing of a shrimper.",
     "difficulty": 0,
     "max_level": 1,
-    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "NO_ARMS" ]
+    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "NO_ARMS", "NO_HANDS" ]
   },
   {
     "id": "soda_armor_normal_item",
@@ -411,7 +411,7 @@
     "warmth": 5,
     "material_thickness": 1.6,
     "environmental_protection": 5,
-    "flags": [ "AURA", "WATER_FRIENDLY" ],
+    "flags": [ "AURA", "WATER_FRIENDLY", "INTEGRATED" ],
     "armor": [
       {
         "coverage": 100,
@@ -443,7 +443,7 @@
     "energy_source": "STAMINA",
     "difficulty": 0,
     "max_level": 1,
-    "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_LEGS", "NO_FAIL", "PERMANENT" ]
+    "flags": [ "SILENT", "CONCENTRATE", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_LEGS", "NO_FAIL", "PERMANENT", "NO_HANDS" ]
   },
   {
     "id": "soda_can_item_empower_act",
@@ -504,7 +504,7 @@
     "message": "Woven cord patches itself together into your outstretched hand, until a pristine woven net is formed.",
     "difficulty": 0,
     "max_level": 1,
-    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS" ]
+    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "NO_HANDS" ]
   },
   {
     "id": "soda_net_empower_item",
@@ -530,7 +530,7 @@
   {
     "id": "EGO_soda_summon_armour_empower",
     "type": "SPELL",
-    "name": "[ז] EGO Soda - Summon armour",
+    "name": "[ז] EGO Soda - Summon Armour",
     "description": "Call forth the armour of a shrimp. The shrimp. WellCheers Shrimp.",
     "valid_targets": [ "self" ],
     "effect": "spawn_item",
@@ -552,7 +552,7 @@
     "message": "The plating of a shrimp envelops you, though formed into the clothing of a dredger.",
     "difficulty": 0,
     "max_level": 1,
-    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "NO_ARMS" ]
+    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "NO_ARMS", "NO_HANDS", "INTEGRATED" ]
   },
   {
     "id": "soda_armor_empowered_item",
@@ -601,7 +601,7 @@
     "energy_source": "STAMINA",
     "difficulty": 3,
     "max_level": 1,
-    "flags": [ "SILENT", "NO_LEGS", "NO_ARMS" ]
+    "flags": [ "SILENT", "NO_LEGS", "NO_ARMS", "NO_HANDS" ]
   },
   {
     "type": "effect_on_condition",
@@ -638,7 +638,7 @@
     "energy_source": "STAMINA",
     "difficulty": 0,
     "max_level": 1,
-    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "NO_ARMS" ]
+    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS", "NO_ARMS", "NO_HANDS" ]
   },
   {
     "type": "effect_on_condition",

--- a/EoCs.json
+++ b/EoCs.json
@@ -172,7 +172,7 @@
       },
       { 
         "if": { "math": [ "u_spell_level('EGO_soda') > -1" ] },
-        "then": [ { "math": [ "u_spell_exp('EGO_soda') += 200" ] }, { "u_message": "You feel Soda resonate, dancing in your subconcious as you drink down more glorious WellCheers."} ]
+        "then": [ { "math": [ "u_spell_exp('EGO_soda') += 2" ] }, { "u_message": "You feel Soda resonate, dancing in your subconcious as you drink down more glorious WellCheers."} ]
       }
     ]
   },
@@ -188,7 +188,7 @@
       },
       { 
         "if": { "math": [ "u_spell_level('EGO_soda') > -1" ] },
-        "then": [ { "math": [ "u_spell_exp('EGO_soda') += 200" ] }, { "u_message": "You feel Soda resonate, dancing in your subconcious as you drink down more glorious WellCheers."} ]
+        "then": [ { "math": [ "u_spell_exp('EGO_soda') += 3" ] }, { "u_message": "You feel Soda resonate, dancing in your subconcious as you drink down more glorious WellCheers."} ]
       }
     ]
   },
@@ -204,7 +204,7 @@
       },
       { 
         "if": { "math": [ "u_spell_level('EGO_soda') > -1" ] },
-        "then": [ { "math": [ "u_spell_exp('EGO_soda') += 400" ] }, { "u_message": "You feel Soda resonate, dancing in your subconcious as you drink down more glorious WellCheers."} ]
+        "then": [ { "math": [ "u_spell_exp('EGO_soda') += 5" ] }, { "u_message": "You feel Soda resonate, dancing in your subconcious as you drink down more glorious WellCheers."} ]
       }
     ]
   },

--- a/Maps/Mapgen/Zwei/Zwei_first_office.json
+++ b/Maps/Mapgen/Zwei/Zwei_first_office.json
@@ -35,7 +35,7 @@
 	"palettes": [ "zwei_palette" ],
 	"place_monster": [ {"group": "PECCA_GENERAL", "x":[6,15], "y":[13,20], "pack_size": [ 1, 2 ], "repeat": [1,3] }],
 	"terrain": {
-		"W": "t_wall_b",
+		"W": "t_wall_train",
 		".": "t_sidewalk",
 		"y": "t_carpet_yellow"
 	}

--- a/Terrain/Terrain.json
+++ b/Terrain/Terrain.json
@@ -1,0 +1,11 @@
+[
+  {
+    "type": "terrain",
+    "id": "t_wall_train",
+    "name": "Test wall",
+    "looks_like": "t_wall",
+    "symbol": "T",
+    "description": "A testing wall for the train.",
+    "color": "light_red"
+  }
+]


### PR DESCRIPTION
Fixes:
- Made drinking Wellcheers give a reasonable amount of xp to Soda, was too much
- Set items to needing the hacksaw quality 'SAW_M'
- Made EGO armour repairable, though no item can repair it currently

Addition
- Test wall for the train, test Zwei headquarters now uses it as a wall