### PR TITLE
Adds W corp equipment

### DIFF
--- a/Items/armor.json
+++ b/Items/armor.json
@@ -16,10 +16,27 @@
     "color": "white",
     "environmental_protection": 5,
     "armor": [
-      { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 100, "encumbrance": [ 2, 6 ] },
-      { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 95 },
-      { "covers": [ "arm_r" ], "coverage": 100, "encumbrance": [ 2, 2 ] },
-      { "covers": [ "arm_l" ], "coverage": 100, "encumbrance": [ 2, 3 ] }
+      {
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_lower" ],
+        "coverage": 100,
+        "encumbrance": [ 2, 6 ]
+      },
+      {
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_upper" ],
+        "coverage": 95
+      },
+      {
+        "covers": [ "arm_r" ],
+        "coverage": 100,
+        "encumbrance": [ 2, 2 ]
+      },
+      {
+        "covers": [ "arm_l" ],
+        "coverage": 100,
+        "encumbrance": [ 2, 3 ]
+      }
     ],
     "pocket_data": [
       {
@@ -84,10 +101,27 @@
     "color": "white",
     "environmental_protection": 5,
     "armor": [
-      { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 100, "encumbrance": [ 2, 6 ] },
-      { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 95 },
-      { "covers": [ "arm_r" ], "coverage": 100, "encumbrance": [ 2, 2 ] },
-      { "covers": [ "arm_l" ], "coverage": 100, "encumbrance": [ 2, 3 ] }
+      {
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_lower" ],
+        "coverage": 100,
+        "encumbrance": [ 2, 6 ]
+      },
+      {
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_upper" ],
+        "coverage": 95
+      },
+      {
+        "covers": [ "arm_r" ],
+        "coverage": 100,
+        "encumbrance": [ 2, 2 ]
+      },
+      {
+        "covers": [ "arm_l" ],
+        "coverage": 100,
+        "encumbrance": [ 2, 3 ]
+      }
     ],
     "pocket_data": [
       {
@@ -141,8 +175,16 @@
     "looks_like": "jacket_jean",
     "to_hit": -2,
     "armor": [
-      { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 7, 12 ] },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 7, 12 ] }
+      {
+        "covers": [ "torso" ],
+        "coverage": 100,
+        "encumbrance": [ 7, 12 ]
+      },
+      {
+        "covers": [ "arm_l", "arm_r" ],
+        "coverage": 100,
+        "encumbrance": [ 7, 12 ]
+      }
     ],
     "pocket_data": [
       {
@@ -182,8 +224,16 @@
     "looks_like": "duster",
     "color": "brown",
     "armor": [
-      { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 9, 16 ] },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 7, 7 ] },
+      {
+        "covers": [ "torso" ],
+        "coverage": 100,
+        "encumbrance": [ 9, 16 ]
+      },
+      {
+        "covers": [ "arm_l", "arm_r" ],
+        "coverage": 100,
+        "encumbrance": [ 7, 7 ]
+      },
       {
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
@@ -243,8 +293,16 @@
     "looks_like": "duster",
     "color": "blue",
     "armor": [
-      { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 6, 8 ] },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 5, 5 ] },
+      {
+        "covers": [ "torso" ],
+        "coverage": 100,
+        "encumbrance": [ 6, 8 ]
+      },
+      {
+        "covers": [ "arm_l", "arm_r" ],
+        "coverage": 100,
+        "encumbrance": [ 5, 5 ]
+      },
       {
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
@@ -304,8 +362,16 @@
     "looks_like": "duster",
     "color": "brown",
     "armor": [
-      { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 4, 7 ] },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 3, 4 ] },
+      {
+        "covers": [ "torso" ],
+        "coverage": 100,
+        "encumbrance": [ 4, 7 ]
+      },
+      {
+        "covers": [ "arm_l", "arm_r" ],
+        "coverage": 100,
+        "encumbrance": [ 3, 4 ]
+      },
       {
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
@@ -354,7 +420,10 @@
     "id": "zw_spads",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "sturdy shoulder pads", "str_pl": "pairs of sturdy shoulderpads" },
+    "name": {
+      "str": "sturdy shoulder pads",
+      "str_pl": "pairs of sturdy shoulderpads"
+    },
     "description": "A shoulder pad made of steel, unusualy sturdy.Two yellow lines painted on it.",
     "weight": "1510 g",
     "volume": "1450 ml",
@@ -384,7 +453,10 @@
     "id": "zw_epads",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "sturdy elbow pad", "str_pl": "pairs of sturdy elbow pads" },
+    "name": {
+      "str": "sturdy elbow pad",
+      "str_pl": "pairs of sturdy elbow pads"
+    },
     "description": "A elbow pad made of steel, unusualy sturdy.Two yellow lines painted on it.",
     "weight": "810 g",
     "volume": "650 ml",
@@ -414,7 +486,10 @@
     "id": "zw_armguard",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "sturdy armguard", "str_pl": "pairs of sturdy armguards" },
+    "name": {
+      "str": "sturdy armguard",
+      "str_pl": "pairs of sturdy armguards"
+    },
     "description": "A armguard made of steel, unusualy sturdy.Two yellow lines painted on it.",
     "weight": "2210 g",
     "volume": "1850 ml",
@@ -443,7 +518,10 @@
   {
     "id": "pm_shirt_yel",
     "type": "ARMOR",
-    "name": { "str": "yellow shirt", "str_pl": "yellow shirts" },
+    "name": {
+      "str": "yellow shirt",
+      "str_pl": "yellow shirts"
+    },
     "description": "A yellow button-down shirt with long sleeves.  Looks professional!",
     "copy-from": "dress_shirt",
     "price_postapoc": "10USD",
@@ -454,7 +532,10 @@
   {
     "id": "pm_blouse_green",
     "type": "ARMOR",
-    "name": { "str": "green blouse", "str_pl": "green blouse's" },
+    "name": {
+      "str": "green blouse",
+      "str_pl": "green blouse's"
+    },
     "description": "A green button-down blouse with long sleeves.  Looks professional!",
     "copy-from": "dress_shirt",
     "price_postapoc": "10USD",
@@ -465,7 +546,10 @@
   {
     "id": "pm_shirt",
     "type": "ARMOR",
-    "name": { "str": "white shirt", "str_pl": "white shirts" },
+    "name": {
+      "str": "white shirt",
+      "str_pl": "white shirts"
+    },
     "description": "A white button-down shirt with long sleeves.  Looks professional!",
     "copy-from": "dress_shirt",
     "price_postapoc": "10USD",
@@ -475,7 +559,10 @@
   {
     "id": "pm_shirt_brown",
     "type": "ARMOR",
-    "name": { "str": "brown shirt", "str_pl": "brown shirts" },
+    "name": {
+      "str": "brown shirt",
+      "str_pl": "brown shirts"
+    },
     "description": "A brown button-down shirt with long sleeves.  Looks professional!",
     "copy-from": "dress_shirt",
     "price_postapoc": "10USD",
@@ -486,7 +573,10 @@
   {
     "id": "kr_shirt",
     "type": "ARMOR",
-    "name": { "str": "black silk shirt", "str_pl": "black silk shirts" },
+    "name": {
+      "str": "black silk shirt",
+      "str_pl": "black silk shirts"
+    },
     "description": "A black button-down silk shirt with long sleeves.  Looks so slick and presentable!",
     "copy-from": "dress_shirt",
     "looks_like": "kr_shirt",
@@ -512,16 +602,33 @@
     "looks_like": "kimono",
     "color": "black",
     "armor": [
-      { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 100, "encumbrance": [ 1, 3 ] },
-      { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 95 },
-      { "covers": [ "leg_l", "leg_r" ], "coverage": 100, "encumbrance": [ 1, 1 ] },
+      {
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_lower" ],
+        "coverage": 100,
+        "encumbrance": [ 1, 3 ]
+      },
+      {
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_upper" ],
+        "coverage": 95
+      },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 100,
+        "encumbrance": [ 1, 1 ]
+      },
       {
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r", "arm_upper_r", "arm_upper_l", "arm_elbow_r", "arm_elbow_l" ],
         "coverage": 100,
         "encumbrance": [ 1, 1 ]
       },
-      { "covers": [ "arm_l", "arm_r" ], "specifically_covers": [ "arm_lower_l", "arm_lower_r" ], "coverage": 95 }
+      {
+        "covers": [ "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_lower_l", "arm_lower_r" ],
+        "coverage": 95
+      }
     ],
     "warmth": 5,
     "material_thickness": 0.15,
@@ -530,7 +637,10 @@
   {
     "id": "pm_gloves",
     "type": "ARMOR",
-    "name": { "str": "pair of sturdy leather gloves", "str_pl": "pairs of sturdy leather gloves" },
+    "name": {
+      "str": "pair of sturdy leather gloves",
+      "str_pl": "pairs of sturdy leather gloves"
+    },
     "description": "A thin pair of black leather gloves. Unusually sturdy.",
     "copy-from": "gloves_leather",
     "material": [ "pm_leather" ],
@@ -542,7 +652,10 @@
   {
     "id": "pm_boots",
     "type": "ARMOR",
-    "name": { "str": "pair of sturdy boots", "str_pl": "pairs of sturdy boots" },
+    "name": {
+      "str": "pair of sturdy boots",
+      "str_pl": "pairs of sturdy boots"
+    },
     "description": "Tough leather boots. Quite refined and well made.",
     "weight": "1360 g",
     "volume": "2645 ml",
@@ -569,7 +682,13 @@
           "foot_arch_r",
           "foot_arch_l"
         ],
-        "material": [ { "type": "pm_leather", "covered_by_mat": 100, "thickness": 2.5 } ],
+        "material": [
+          {
+            "type": "pm_leather",
+            "covered_by_mat": 100,
+            "thickness": 2.5
+          }
+        ],
         "encumbrance": 12,
         "coverage": 100
       },
@@ -577,8 +696,16 @@
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
         "material": [
-          { "type": "pm_leather", "covered_by_mat": 100, "thickness": 0.1 },
-          { "type": "rubber", "covered_by_mat": 100, "thickness": 6.0 }
+          {
+            "type": "pm_leather",
+            "covered_by_mat": 100,
+            "thickness": 0.1
+          },
+          {
+            "type": "rubber",
+            "covered_by_mat": 100,
+            "thickness": 6.0
+          }
         ],
         "coverage": 100
       }
@@ -604,7 +731,10 @@
     "id": "kr_eyepatch",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "kurokumo eyepatch", "str_pl": "kurokumo eyepatches" },
+    "name": {
+      "str": "kurokumo eyepatch",
+      "str_pl": "kurokumo eyepatches"
+    },
     "description": "Stylish eyepatch. And, somehow, it almost doesn't interfere with vision!",
     "weight": "50 g",
     "volume": "100 ml",
@@ -617,7 +747,14 @@
     "color": "black",
     "material_thickness": 1,
     "flags": [ "WATER_FRIENDLY", "SKINTIGHT", "FANCY" ],
-    "armor": [ { "encumbrance": 10, "coverage": 50, "covers": [ "eyes" ], "rigid_layer_only": true } ]
+    "armor": [
+      {
+        "encumbrance": 10,
+        "coverage": 50,
+        "covers": [ "eyes" ],
+        "rigid_layer_only": true
+      }
+    ]
   },
   {
     "id": "pm_trouses",
@@ -653,7 +790,13 @@
     "warmth": 8,
     "material_thickness": 0.2,
     "flags": [ "VARSIZE", "POCKETS", "FANCY" ],
-    "armor": [ { "encumbrance": [ 5, 7 ], "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [
+      {
+        "encumbrance": [ 5, 7 ],
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r" ]
+      }
+    ]
   },
   {
     "id": "pm_trouses_brown",
@@ -689,7 +832,13 @@
     "warmth": 8,
     "material_thickness": 0.8,
     "flags": [ "VARSIZE", "POCKETS", "STURDY" ],
-    "armor": [ { "encumbrance": [ 5, 7 ], "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [
+      {
+        "encumbrance": [ 5, 7 ],
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r" ]
+      }
+    ]
   },
   {
     "id": "kr_trouses",
@@ -725,12 +874,21 @@
     "warmth": 8,
     "material_thickness": 0.2,
     "flags": [ "VARSIZE", "POCKETS", "STURDY", "SUPER_FANCY" ],
-    "armor": [ { "encumbrance": [ 5, 7 ], "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [
+      {
+        "encumbrance": [ 5, 7 ],
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r" ]
+      }
+    ]
   },
   {
     "id": "kr_suit",
     "type": "ARMOR",
-    "name": { "str": "Black suit", "str_pl": "Black suits" },
+    "name": {
+      "str": "Black suit",
+      "str_pl": "Black suits"
+    },
     "description": "A full-body black cotton suit with silk padding. Looks impresive and expensive ",
     "copy-from": "suit",
     "looks_like": "suit",
@@ -743,7 +901,10 @@
   {
     "id": "kr_blazer",
     "type": "ARMOR",
-    "name": { "str": "Black blazer", "str_pl": "Black blazers" },
+    "name": {
+      "str": "Black blazer",
+      "str_pl": "Black blazers"
+    },
     "description": "A black blazer with silk padding. Looks impresive and expensive ",
     "copy-from": "blazer",
     "looks_like": "blazer",
@@ -756,7 +917,10 @@
   {
     "id": "pm_blazer",
     "type": "ARMOR",
-    "name": { "str": "blazer", "str_pl": "blazers" },
+    "name": {
+      "str": "blazer",
+      "str_pl": "blazers"
+    },
     "description": "A black cotton blazer. ",
     "copy-from": "blazer",
     "looks_like": "blazer",
@@ -767,7 +931,10 @@
   {
     "id": "pm_labcoat",
     "type": "ARMOR",
-    "name": { "str": "fine lab coat", "str_pl": " fine lab coats" },
+    "name": {
+      "str": "fine lab coat",
+      "str_pl": " fine lab coats"
+    },
     "copy-from": "coat_lab",
     "price_postapoc": "20 USD",
     "looks_like": "coat_lab",
@@ -785,7 +952,10 @@
   {
     "id": "lc_labcoat",
     "type": "ARMOR",
-    "name": { "str": "L. lab coat", "str_pl": "L. lab coats" },
+    "name": {
+      "str": "L. lab coat",
+      "str_pl": "L. lab coats"
+    },
     "copy-from": "coat_lab",
     "price_postapoc": "30 USD",
     "looks_like": "coat_lab",
@@ -794,7 +964,10 @@
   {
     "id": "lc_trouses",
     "type": "ARMOR",
-    "name": { "str": "L. brown trouses", "str_pl": "L. brown trouses" },
+    "name": {
+      "str": "L. brown trouses",
+      "str_pl": "L. brown trouses"
+    },
     "description": "A pair of brown trouses. Looks professional!",
     "copy-from": "pm_trouses",
     "price_postapoc": "20 USD",
@@ -824,8 +997,17 @@
     "armor": [
       {
         "material": [
-          { "type": "l_cotton", "covered_by_mat": 100, "thickness": 0.5 },
-          { "type": "b_polymer", "covered_by_mat": 95, "thickness": 3.3, "ignore_sheet_thickness": true }
+          {
+            "type": "l_cotton",
+            "covered_by_mat": 100,
+            "thickness": 0.5
+          },
+          {
+            "type": "b_polymer",
+            "covered_by_mat": 95,
+            "thickness": 3.3,
+            "ignore_sheet_thickness": true
+          }
         ],
         "encumbrance": 3,
         "coverage": 94,
@@ -835,8 +1017,17 @@
       },
       {
         "material": [
-          { "type": "l_cotton", "covered_by_mat": 100, "thickness": 0.5 },
-          { "type": "b_polymer", "covered_by_mat": 95, "thickness": 3.3, "ignore_sheet_thickness": true }
+          {
+            "type": "l_cotton",
+            "covered_by_mat": 100,
+            "thickness": 0.5
+          },
+          {
+            "type": "b_polymer",
+            "covered_by_mat": 95,
+            "thickness": 3.3,
+            "ignore_sheet_thickness": true
+          }
         ],
         "encumbrance": 0,
         "coverage": 85,
@@ -850,7 +1041,10 @@
   {
     "id": "pm_brown_shoes",
     "type": "ARMOR",
-    "name": { "str": "pair of brown shoes", "str_pl": "pairs of brown shoes" },
+    "name": {
+      "str": "pair of brown shoes",
+      "str_pl": "pairs of brown shoes"
+    },
     "description": "Fancy patent leather shoes.  Not designed for running. Do you wonder who they might belong to?",
     "weight": "870 g",
     "volume": "1500 ml",
@@ -869,22 +1063,42 @@
       {
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_heel_r", "foot_heel_l", "foot_arch_r", "foot_arch_l", "foot_toes_r", "foot_toes_l" ],
-        "material": [ { "type": "pm_leather", "covered_by_mat": 100, "thickness": 2 } ],
+        "material": [
+          {
+            "type": "pm_leather",
+            "covered_by_mat": 100,
+            "thickness": 2
+          }
+        ],
         "encumbrance": 15,
         "coverage": 100
       },
       {
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_ankle_r", "foot_ankle_l" ],
-        "material": [ { "type": "pm_leather", "covered_by_mat": 100, "thickness": 2.0 } ],
+        "material": [
+          {
+            "type": "pm_leather",
+            "covered_by_mat": 100,
+            "thickness": 2.0
+          }
+        ],
         "coverage": 40
       },
       {
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
         "material": [
-          { "type": "pm_leather", "covered_by_mat": 100, "thickness": 0.1 },
-          { "type": "rubber", "covered_by_mat": 100, "thickness": 4.0 }
+          {
+            "type": "pm_leather",
+            "covered_by_mat": 100,
+            "thickness": 0.1
+          },
+          {
+            "type": "rubber",
+            "covered_by_mat": 100,
+            "thickness": 4.0
+          }
         ],
         "coverage": 100
       }
@@ -939,7 +1153,10 @@
   {
     "type": "ARMOR",
     "id": "ego_suit",
-    "name": { "str": "EGO Suit", "str_pl": "EGO Suits" },
+    "name": {
+      "str": "EGO Suit",
+      "str_pl": "EGO Suits"
+    },
     "description": "A heavy suit of armor with plates protecting vital areas. Capable of contain EGO",
     "weight": "15 kg",
     "volume": "8 L",
@@ -985,17 +1202,37 @@
           "leg_lower_r"
         ],
         "material": [
-          { "type": "b_polymer", "covered_by_mat": 30, "thickness": 3 },
-          { "type": "l_steel", "covered_by_mat": 40, "thickness": 4 },
-          { "type": "l_cotton", "covered_by_mat": 100, "thickness": 2 }
+          {
+            "type": "b_polymer",
+            "covered_by_mat": 30,
+            "thickness": 3
+          },
+          {
+            "type": "l_steel",
+            "covered_by_mat": 40,
+            "thickness": 4
+          },
+          {
+            "type": "l_cotton",
+            "covered_by_mat": 100,
+            "thickness": 2
+          }
         ]
       },
       {
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
         "material": [
-          { "type": "b_polymer", "covered_by_mat": 100, "thickness": 2.0 },
-          { "type": "l_steel", "covered_by_mat": 100, "thickness": 6.0 }
+          {
+            "type": "b_polymer",
+            "covered_by_mat": 100,
+            "thickness": 2.0
+          },
+          {
+            "type": "l_steel",
+            "covered_by_mat": 100,
+            "thickness": 6.0
+          }
         ],
         "coverage": 100
       }
@@ -1005,7 +1242,10 @@
     "id": "cuirass_lightplate_test",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "cuirass test PM", "str_pl": "cuirasses" },
+    "name": {
+      "str": "cuirass test PM",
+      "str_pl": "cuirasses"
+    },
     "description": "A steel breastplate, and a vital part of plate armor.  Even as full armor went into decline, cuirasses remained in use among cavalry in Europe.",
     "weight": "4200 g",
     "volume": "6 L",
@@ -1021,7 +1261,11 @@
     "material_thickness": 4,
     "flags": [ "VARSIZE", "OUTER", "STURDY" ],
     "armor": [
-      { "encumbrance": 20, "coverage": 95, "covers": [ "torso" ] },
+      {
+        "encumbrance": 20,
+        "coverage": 95,
+        "covers": [ "torso" ]
+      },
       {
         "encumbrance": 4,
         "coverage": 95,
@@ -1050,8 +1294,16 @@
     "looks_like": "jacket_jean",
     "to_hit": -2,
     "armor": [
-      { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 2, 4 ] },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 2, 4 ] }
+      {
+        "covers": [ "torso" ],
+        "coverage": 100,
+        "encumbrance": [ 2, 4 ]
+      },
+      {
+        "covers": [ "arm_l", "arm_r" ],
+        "coverage": 100,
+        "encumbrance": [ 2, 4 ]
+      }
     ],
     "pocket_data": [
       {
@@ -1074,6 +1326,422 @@
     "warmth": 24,
     "environmental_protection": 1,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "STURDY"]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "STURDY" ]
+  },
+  {
+    "id": "w_shirt",
+    "type": "ARMOR",
+    "name": { "str": "W Corp shirt" },
+    "description": "A dark formal shirt worn by employees of W Corp.",
+    "copy-from": "dress_shirt",
+    "price_postapoc": "10USD",
+    "looks_like": "pm_shirt_yel",
+    "material": [ "pm_cotton" ],
+    "repairs_with": [ "pm_cotton_item" ]
+  },
+  {
+    "id": "w_trousers",
+    "type": "ARMOR",
+    "name": { "str_sp": "W Corp trousers" },
+    "description": "A pair of dark blue trousers worn by employees of W Corp.",
+    "weight": "421 g",
+    "volume": "2 L",
+    "price": "12 USD",
+    "price_postapoc": "7 USD",
+    "to_hit": 1,
+    "material": [ "pm_cotton" ],
+    "repairs_with": [ "pm_cotton_item" ],
+    "symbol": "[",
+    "looks_like": "pants",
+    "color": "black",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "750 ml",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "11 cm",
+        "moves": 90
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "750 ml",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "11 cm",
+        "moves": 90
+      }
+    ],
+    "warmth": 8,
+    "material_thickness": 0.2,
+    "flags": [ "VARSIZE", "POCKETS", "FANCY" ],
+    "armor": [
+      {
+        "encumbrance": [ 3, 5 ],
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r" ]
+      }
+    ]
+  },
+  {
+    "id": "w_cap",
+    "type": "ARMOR",
+    "name": {
+      "str": "W Corp cap"
+    },
+    "description": "A black cap with the logo of W corp embroidered on the front.",
+    "weight": "92 g",
+    "volume": "500 ml",
+    "price": "15 USD",
+    "price_postapoc": "80 cent",
+    "material": [
+      "cotton"
+    ],
+    "symbol": "[",
+    "looks_like": "hat_ball",
+    "color": "dark_gray",
+    "warmth": 5,
+    "material_thickness": 0.3,
+    "environmental_protection": 1,
+    "flags": [
+      "VARSIZE",
+      "SUN_GLASSES"
+    ],
+    "armor": [
+      {
+        "encumbrance_modifiers": [
+          "NONE"
+        ],
+        "coverage": 100,
+        "covers": [
+          "head"
+        ],
+        "specifically_covers": [
+          "head_crown",
+          "head_forehead"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "w_l2_chestpiece",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "L2 cleanup agent chestpiece" },
+    "description": "A sturdy chestpiece worn by junior W Corp cleanup agents. Most agents will only wear this once before they quit or suffer an unfortunate workplace accident, and it seems you're the latest in that line. Designed to prioritise mobility and protect you from electric shocks.",
+    "weight": "3260 g",
+    "volume": "5 L",
+    "price": "350 USD",
+    "price_postapoc": "140 USD",
+    "to_hit": -3,
+    "material": [ "b_polymer", "l_cotton" ],
+    "repairs_with": [ "b_polymer_item" ],
+    "symbol": "[",
+    "looks_like": "vest_leather",
+    "color": "light_gray",
+    "warmth": 15,
+    "material_thickness": 4,
+    "flags": [ "STURDY", "ELECTRIC_IMMUNE" ],
+    "armor": [
+      {
+        "material": [
+          {
+            "type": "l_cotton",
+            "covered_by_mat": 100,
+            "thickness": 0.5
+          },
+          {
+            "type": "b_polymer",
+            "covered_by_mat": 95,
+            "thickness": 3.3,
+            "ignore_sheet_thickness": true
+          }
+        ],
+        "encumbrance": 3,
+        "coverage": 94,
+        "cover_vitals": 70,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_upper" ]
+      },
+      {
+        "material": [
+          {
+            "type": "l_cotton",
+            "covered_by_mat": 100,
+            "thickness": 0.5
+          },
+          {
+            "type": "b_polymer",
+            "covered_by_mat": 95,
+            "thickness": 3.3,
+            "ignore_sheet_thickness": true
+          }
+        ],
+        "encumbrance": 0,
+        "coverage": 85,
+        "cover_vitals": 60,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_lower" ]
+      }
+    ],
+    "melee_damage": { "bash": 6 }
+  },
+  {
+    "id": "w_l3_chestpiece",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "L3 cleanup agent chestpiece" },
+    "description": "A sturdy chestpiece worn by senior W Corp cleanup agents. You hear a small crackling noise coming from within the armor, and the chestpiece itself is warm to the touch. Either way, it appears safe to wear, and doesn't impede your movements much. ",
+    "weight": "3260 g",
+    "volume": "5 L",
+    "price": "350 USD",
+    "price_postapoc": "140 USD",
+    "to_hit": -3,
+    "material": [ "b_polymer", "l_cotton" ],
+    "repairs_with": [ "b_polymer_item" ],
+    "symbol": "[",
+    "looks_like": "vest_leather",
+    "color": "light_gray",
+    "warmth": 15,
+    "material_thickness": 4,
+    "flags": [ "STURDY", "ELECTRIC_IMMUNE" ],
+    "armor": [
+      {
+        "material": [
+          {
+            "type": "l_cotton",
+            "covered_by_mat": 100,
+            "thickness": 0.5
+          },
+          {
+            "type": "b_polymer",
+            "covered_by_mat": 95,
+            "thickness": 3.3,
+            "ignore_sheet_thickness": true
+          }
+        ],
+        "encumbrance": 3,
+        "coverage": 94,
+        "cover_vitals": 70,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_upper" ]
+      },
+      {
+        "material": [
+          {
+            "type": "l_cotton",
+            "covered_by_mat": 100,
+            "thickness": 0.5
+          },
+          {
+            "type": "b_polymer",
+            "covered_by_mat": 95,
+            "thickness": 3.3,
+            "ignore_sheet_thickness": true
+          }
+        ],
+        "encumbrance": 0,
+        "coverage": 85,
+        "cover_vitals": 60,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_lower" ]
+      }
+    ],
+    "melee_damage": { "bash": 6 }
+  },
+  {
+    "id": "w_bracers",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": {
+      "str": "Cleanup agent bracers",
+      "str_pl": "Pairs of cleanup agent bracers"
+    },
+    "description": "A pair of metalic bracers, used to protect your arms from harm. They're lighter than you expected.",
+    "weight": "1500 g",
+    "volume": "1850 ml",
+    "price_postapoc": "40 USD",
+    "to_hit": -1,
+    "material": [ "pm_steel" ],
+    "repairs_with": [ "pm_steel_item" ],
+    "symbol": "[",
+    "looks_like": "armguard_hard",
+    "color": "dark_gray",
+    "material_thickness": 3.5,
+    "sided": true,
+    "flags": [ "WATER_FRIENDLY", "BELTED", "BLOCK_WHILE_WORN", "STURDY" ],
+    "armor": [
+      {
+        "covers": [ "arm_l", "arm_r" ],
+        "encumbrance": 3,
+        "coverage": 90,
+        "cover_melee": 90,
+        "cover_ranged": 95,
+        "cover_vitals": 90,
+        "specifically_covers": [ "arm_lower_l", "arm_lower_r" ]
+      }
+    ]
+  },
+  {
+    "id": "w_gloves",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": {
+      "str": "Pair of cleanup agent gloves",
+      "str_pl": "Pairs of cleanup agent gloves"
+    },
+    "description": "A pair of cut resistant gloves worn by W Corp cleanup agents.'",
+    "weight": "220 g",
+    "volume": "500 ml",
+    "price": "52 USD",
+    "price_postapoc": "15 USD",
+    "material": [
+      "kevlar",
+      "leather"
+    ],
+    "symbol": "[",
+    "looks_like": "fire_gauntlets",
+    "color": "dark_gray",
+    "warmth": 20,
+    "material_thickness": 2,
+    "environmental_protection": 4,
+    "flags": [
+      "VARSIZE",
+      "STURDY"
+    ],
+    "armor": [
+      {
+        "encumbrance": 6,
+        "coverage": 100,
+        "covers": [
+          "hand_l",
+          "hand_r"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "w_boots",
+    "type": "ARMOR",
+    "name": {
+      "str": "Pair of cleanup agent boots",
+      "str_pl": "Pairs of cleanup agent boots"
+    },
+    "description": "A pair of surprisingly tough leather boots, designed to be easy to clean and wash in tandem with proprietary W Corp detergents.",
+    "weight": "1360 g",
+    "volume": "2645 ml",
+    "price": "100 USD",
+    "price_postapoc": "20 USD",
+    "to_hit": -1,
+    "symbol": "[",
+    "repairs_with": [ "pm_leather_item" ],
+    "looks_like": "dress_shoes",
+    "color": "dark_gray",
+    "warmth": 16,
+    "environmental_protection": 3,
+    "flags": [ "VARSIZE", "WATERPROOF" ],
+    "armor": [
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [
+          "foot_toes_r",
+          "foot_toes_l",
+          "foot_ankle_r",
+          "foot_ankle_l",
+          "foot_heel_r",
+          "foot_heel_l",
+          "foot_arch_r",
+          "foot_arch_l"
+        ],
+        "material": [
+          {
+            "type": "pm_leather",
+            "covered_by_mat": 100,
+            "thickness": 2.5
+          }
+        ],
+        "encumbrance": 12,
+        "coverage": 100
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
+        "material": [
+          {
+            "type": "pm_leather",
+            "covered_by_mat": 100,
+            "thickness": 0.1
+          },
+          {
+            "type": "rubber",
+            "covered_by_mat": 100,
+            "thickness": 6.0
+          }
+        ],
+        "coverage": 100
+      }
+    ],
+    "melee_damage": { "bash": 2 }
+  },
+  {
+    "id": "w_advanced_boots",
+    "type": "ARMOR",
+    "name": {
+      "str": "Pair of advanced cleanup agent boots",
+      "str_pl": "Pairs of advanced cleanup agent boots"
+    },
+    "description": "A pair of tough metallic greaves that lead up to the ankle. When powered, they grant improve mobility and secure the user to the ground, even in areas of low gravity or poor dimensional stability. Worn exclusively by high ranking W Corp cleanup agents.",
+    "weight": "1360 g",
+    "volume": "2645 ml",
+    "price": "100 USD",
+    "price_postapoc": "20 USD",
+    "to_hit": -1,
+    "symbol": "[",
+    "repairs_with": [ "pm_steel" ],
+    "looks_like": "dress_shoes",
+    "color": "dark_gray",
+    "warmth": 16,
+    "environmental_protection": 3,
+    "flags": [ "VARSIZE", "WATERPROOF" ],
+    "armor": [
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [
+          "foot_toes_r",
+          "foot_toes_l",
+          "foot_ankle_r",
+          "foot_ankle_l",
+          "foot_heel_r",
+          "foot_heel_l",
+          "foot_arch_r",
+          "foot_arch_l"
+        ],
+        "material": [
+          {
+            "type": "pm_leather",
+            "covered_by_mat": 100,
+            "thickness": 2.5
+          }
+        ],
+        "encumbrance": 12,
+        "coverage": 100
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
+        "material": [
+          {
+            "type": "pm_steel",
+            "covered_by_mat": 100,
+            "thickness": 0.1
+          },
+          {
+            "type": "rubber",
+            "covered_by_mat": 100,
+            "thickness": 6.0
+          }
+        ],
+        "coverage": 100
+      }
+    ],
+    "melee_damage": { "bash": 2 }
   }
 ]

--- a/Items/melee.json
+++ b/Items/melee.json
@@ -13,14 +13,34 @@
     "looks_like": "zweihander",
     "price": "2200 USD",
     "price_postapoc": "280 USD",
-    "material": [ { "type": "pm_leather", "portion": 1.1 }, { "type": "b_steel", "portion": 160 } ],
+    "material": [
+      {
+        "type": "pm_leather",
+        "portion": 1.1
+      },
+      {
+        "type": "b_steel",
+        "portion": 160
+      }
+    ],
     "repairs_with": [ "b_steel_item" ],
     "flags": [ "ALWAYS_TWOHAND", "DURABLE_MELEE", "SHEATH_SWORD", "REACH_ATTACK" ],
     "techniques": [ "WBLOCK_1", "WIDE", "BRUTAL", "SWEEP" ],
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "good" },
-    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 2 ] ],
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "line",
+      "balance": "good"
+    },
+    "qualities": [
+      [ "CUT", 1 ],
+      [ "BUTCHER", 2 ]
+    ],
     "weapon_category": [ "GREAT_SWORDS" ],
-    "melee_damage": { "bash": 24, "cut": 37 }
+    "melee_damage": {
+      "bash": 24,
+      "cut": 37
+    }
   },
   {
     "id": "zw_bscabbard",
@@ -47,9 +67,20 @@
         "flag_restriction": [ "SHEATH_SWORD" ]
       }
     ],
-    "use_action": { "type": "holster", "holster_prompt": "Sheath sword", "holster_msg": "You sheath your %s" },
+    "use_action": {
+      "type": "holster",
+      "holster_prompt": "Sheath sword",
+      "holster_msg": "You sheath your %s"
+    },
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY", "TARDIS" ],
-    "armor": [ { "encumbrance": [ 6, 14 ], "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ],
+    "armor": [
+      {
+        "encumbrance": [ 6, 14 ],
+        "coverage": 20,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_hanging_back" ]
+      }
+    ],
     "melee_damage": { "bash": 4 }
   },
   {
@@ -66,14 +97,34 @@
     "looks_like": "zweihander",
     "price": "2200 USD",
     "price_postapoc": "300 USD",
-    "material": [ { "type": "pm_leather", "portion": 1.1 }, { "type": "b_steel", "portion": 160 } ],
+    "material": [
+      {
+        "type": "pm_leather",
+        "portion": 1.1
+      },
+      {
+        "type": "b_steel",
+        "portion": 160
+      }
+    ],
     "repairs_with": [ "b_steel_item" ],
     "flags": [ "ALWAYS_TWOHAND", "DURABLE_MELEE", "SHEATH_SWORD", "REACH_ATTACK", "SLOW_WIELD" ],
     "techniques": [ "WBLOCK_1", "WIDE", "BRUTAL", "SWEEP" ],
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "good" },
-    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 2 ] ],
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "line",
+      "balance": "good"
+    },
+    "qualities": [
+      [ "CUT", 1 ],
+      [ "BUTCHER", 2 ]
+    ],
     "weapon_category": [ "GREAT_SWORDS" ],
-    "melee_damage": { "bash": 31, "cut": 45 }
+    "melee_damage": {
+      "bash": 31,
+      "cut": 45
+    }
   },
   {
     "id": "zw_bscabbard_iz",
@@ -100,9 +151,20 @@
         "flag_restriction": [ "SHEATH_SWORD" ]
       }
     ],
-    "use_action": { "type": "holster", "holster_prompt": "Sheath sword", "holster_msg": "You sheath your %s" },
+    "use_action": {
+      "type": "holster",
+      "holster_prompt": "Sheath sword",
+      "holster_msg": "You sheath your %s"
+    },
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY", "TARDIS" ],
-    "armor": [ { "encumbrance": [ 6, 14 ], "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ],
+    "armor": [
+      {
+        "encumbrance": [ 6, 14 ],
+        "coverage": 20,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_hanging_back" ]
+      }
+    ],
     "melee_damage": { "bash": 4 }
   },
   {
@@ -119,14 +181,34 @@
     "looks_like": "longsword",
     "price": "1200 USD",
     "price_postapoc": "215 USD",
-    "material": [ { "type": "pm_leather", "portion": 1.1 }, { "type": "b_steel", "portion": 112 } ],
+    "material": [
+      {
+        "type": "pm_leather",
+        "portion": 1.1
+      },
+      {
+        "type": "b_steel",
+        "portion": 112
+      }
+    ],
     "repairs_with": [ "b_steel_item" ],
     "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ],
     "techniques": [ "WBLOCK_1", "BRUTAL", "RAPID" ],
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "good" },
-    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 6 ] ],
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "line",
+      "balance": "good"
+    },
+    "qualities": [
+      [ "CUT", 1 ],
+      [ "BUTCHER", 6 ]
+    ],
     "weapon_category": [ "LONG_SWORDS", "GREAT_SWORDS" ],
-    "melee_damage": { "bash": 11, "cut": 35 }
+    "melee_damage": {
+      "bash": 11,
+      "cut": 35
+    }
   },
   {
     "type": "GENERIC",
@@ -145,7 +227,12 @@
     "volume": "1350 ml",
     "longest_side": "80 cm",
     "//": "Same total damage and slightly higher weight than a morningstar - exchanged.",
-    "to_hit": { "grip": "weapon", "length": "short", "surface": "any", "balance": "neutral" },
+    "to_hit": {
+      "grip": "weapon",
+      "length": "short",
+      "surface": "any",
+      "balance": "neutral"
+    },
     "price": "1000 USD",
     "price_postapoc": "210 USD",
     "qualities": [ [ "HAMMER", 1 ] ],
@@ -166,14 +253,34 @@
     "looks_like": "rapier",
     "price": "980 USD",
     "price_postapoc": "250 USD",
-    "material": [ { "type": "pm_leather", "portion": 1.1 }, { "type": "pm_steel", "portion": 112 } ],
+    "material": [
+      {
+        "type": "pm_leather",
+        "portion": 1.1
+      },
+      {
+        "type": "pm_steel",
+        "portion": 112
+      }
+    ],
     "repairs_with": [ "pm_steel_item" ],
     "flags": [ "DURABLE_MELEE", "CONDUCTIVE", "SHEATH_SWORD" ],
     "techniques": [ "RAPID", "WBLOCK_2", "PRECISE", "DEF_DISARM" ],
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "good" },
-    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 6 ] ],
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "line",
+      "balance": "good"
+    },
+    "qualities": [
+      [ "CUT", 1 ],
+      [ "BUTCHER", 6 ]
+    ],
     "weapon_category": [ "FENCING_WEAPONRY" ],
-    "melee_damage": { "bash": 1, "stab": 37 }
+    "melee_damage": {
+      "bash": 1,
+      "stab": 37
+    }
   },
   {
     "id": "mc_estoc",
@@ -189,14 +296,34 @@
     "looks_like": "estoc",
     "price": "1350 USD",
     "price_postapoc": "250 USD",
-    "material": [ { "type": "pm_leather", "portion": 1.1 }, { "type": "pm_steel", "portion": 112 } ],
+    "material": [
+      {
+        "type": "pm_leather",
+        "portion": 1.1
+      },
+      {
+        "type": "pm_steel",
+        "portion": 112
+      }
+    ],
     "repairs_with": [ "pm_steel_item" ],
     "techniques": [ "WBLOCK_2", "PRECISE", "WIDE" ],
     "flags": [ "SHEATH_SWORD", "CONDUCTIVE", "DURABLE_MELEE" ],
     "weapon_category": [ "LONG_SWORDS", "FENCING_WEAPONRY" ],
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "point", "balance": "good" },
-    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 8 ] ],
-    "melee_damage": { "bash": 2, "stab": 40 }
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "point",
+      "balance": "good"
+    },
+    "qualities": [
+      [ "CUT", 1 ],
+      [ "BUTCHER", 8 ]
+    ],
+    "melee_damage": {
+      "bash": 2,
+      "stab": 40
+    }
   },
   {
     "id": "bl_katana",
@@ -212,21 +339,40 @@
     "looks_like": "katana",
     "price": "150 USD",
     "price_postapoc": "140 USD",
-    "material": [ { "type": "b_steel", "portion": 160 } ],
+    "material": [
+      {
+        "type": "b_steel",
+        "portion": 160
+      }
+    ],
     "repairs_with": [ "b_steel_item" ],
     "flags": [ "DURABLE_MELEE" ],
     "techniques": [ "WBLOCK_2", "BRUTAL", "WIDE", "RAPID" ],
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "good" },
-    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 14 ] ],
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "line",
+      "balance": "good"
+    },
+    "qualities": [
+      [ "CUT", 1 ],
+      [ "BUTCHER", 14 ]
+    ],
     "weapon_category": [ "JAPANESE_SWORDS", "MEDIUM_SWORDS" ],
-    "melee_damage": { "bash": 7, "cut": 52 }
+    "melee_damage": {
+      "bash": 7,
+      "cut": 52
+    }
   },
   {
     "type": "ARMOR",
     "id": "rc_chains",
     "symbol": "3",
     "color": "light_gray",
-    "name": { "str": "hand chain", "str_pl": "hand chains" },
+    "name": {
+      "str": "hand chain",
+      "str_pl": "hand chains"
+    },
     "looks_like": "chain",
     "description": "A lengty steel chain which you wraped around your fits. Quite encumbraing but those weighty punches will hit like a train",
     "material": [ "b_steel" ],
@@ -234,7 +380,12 @@
     "volume": "390 ml",
     "weight": "340 g",
     "price_postapoc": "2 USD",
-    "to_hit": { "grip": "weapon", "length": "hand", "surface": "any", "balance": "neutral" },
+    "to_hit": {
+      "grip": "weapon",
+      "length": "hand",
+      "surface": "any",
+      "balance": "neutral"
+    },
     "qualities": [ [ "HAMMER", 1 ] ],
     "flags": [ "DURABLE_MELEE", "CONDUCTIVE" ],
     "techniques": [ "WIDE", "BRUTAL" ],
@@ -247,7 +398,10 @@
         "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ]
       }
     ],
-    "melee_damage": { "bash": 8, "stab": 3 }
+    "melee_damage": {
+      "bash": 8,
+      "stab": 3
+    }
   },
   {
     "type": "GENERIC",
@@ -255,7 +409,10 @@
     "category": "weapons",
     "price": "52 USD",
     "price_postapoc": "8 USD",
-    "name": { "str": "laboratory throwing knife", "str_pl": "laboratory throwing knifes" },
+    "name": {
+      "str": "laboratory throwing knife",
+      "str_pl": "laboratory throwing knifes"
+    },
     "symbol": ";",
     "color": "light_gray",
     "description": "A extremely thin, flat knife made for throwing. Cold at touch and incredebly light. So sharp that it can even pierce armor, but because of its very small size and lack of a normal handle, it is very difficult to make the necessary effort to do at least something in close combat",
@@ -267,8 +424,17 @@
     "to_hit": -3,
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK", "FRAGILE_MELEE" ],
     "weapon_category": [ "KNIVES" ],
-    "thrown_damage": [ { "damage_type": "stab", "amount": 23, "armor_penetration": 21 } ],
-    "melee_damage": { "bash": 1, "stab": 3 }
+    "thrown_damage": [
+      {
+        "damage_type": "stab",
+        "amount": 23,
+        "armor_penetration": 21
+      }
+    ],
+    "melee_damage": {
+      "bash": 1,
+      "stab": 3
+    }
   },
   {
     "id": "kr_katana",
@@ -285,14 +451,34 @@
     "looks_like": "katana",
     "price": "400 USD",
     "price_postapoc": "155 USD",
-    "material": [ { "type": "pm_leather", "portion": 1.1 }, { "type": "c_steel", "portion": 96 } ],
+    "material": [
+      {
+        "type": "pm_leather",
+        "portion": 1.1
+      },
+      {
+        "type": "c_steel",
+        "portion": 96
+      }
+    ],
     "repairs_with": [ "c_steel_item" ],
     "flags": [ "DURABLE_MELEE", "CONDUCTIVE", "SHEATH_SWORD" ],
     "techniques": [ "RAPID", "WBLOCK_2", "PRECISE" ],
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "good" },
-    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 21 ] ],
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "line",
+      "balance": "good"
+    },
+    "qualities": [
+      [ "CUT", 1 ],
+      [ "BUTCHER", 21 ]
+    ],
     "weapon_category": [ "MEDIUM_SWORDS" ],
-    "melee_damage": { "bash": 5, "cut": 43 }
+    "melee_damage": {
+      "bash": 5,
+      "cut": 43
+    }
   },
   {
     "id": "kr_cloud_katana",
@@ -309,20 +495,43 @@
     "looks_like": "katana",
     "price": "800 USD",
     "price_postapoc": "145 USD",
-    "material": [ { "type": "pm_leather", "portion": 1.1 }, { "type": "c_steel", "portion": 96 } ],
+    "material": [
+      {
+        "type": "pm_leather",
+        "portion": 1.1
+      },
+      {
+        "type": "c_steel",
+        "portion": 96
+      }
+    ],
     "repairs_with": [ "c_steel_item" ],
     "flags": [ "DURABLE_MELEE", "CONDUCTIVE", "SHEATH_SWORD" ],
     "techniques": [ "RAPID", "WBLOCK_2", "PRECISE" ],
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "good" },
-    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 21 ] ],
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "line",
+      "balance": "good"
+    },
+    "qualities": [
+      [ "CUT", 1 ],
+      [ "BUTCHER", 21 ]
+    ],
     "weapon_category": [ "MEDIUM_SWORDS" ],
-    "melee_damage": { "bash": 5, "cut": 51 }
+    "melee_damage": {
+      "bash": 5,
+      "cut": 51
+    }
   },
   {
     "type": "GENERIC",
     "id": "lab_bat",
     "category": "weapons",
-    "name": { "str": "lab security baton", "str_pl": "lab security batons" },
+    "name": {
+      "str": "lab security baton",
+      "str_pl": "lab security batons"
+    },
     "description": "Used by lab security personal. Does little damage but quite light",
     "weight": "380 g",
     "color": "dark_gray",
@@ -335,7 +544,12 @@
     "weapon_category": [ "BATONS", "FENCING_WEAPONRY" ],
     "volume": "1 L",
     "longest_side": "50 cm",
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "good" },
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "any",
+      "balance": "good"
+    },
     "price": "300 USD",
     "price_postapoc": "20 USD",
     "//": "Make a percentage of armor penetration, around 35%",
@@ -345,7 +559,10 @@
     "type": "GENERIC",
     "id": "ego_case",
     "category": "weapons",
-    "name": { "str": "EGO suitcase", "str_pl": "EGO suitcases" },
+    "name": {
+      "str": "EGO suitcase",
+      "str_pl": "EGO suitcases"
+    },
     "description": "Suitcase for transporting EGO. That one without marking",
     "weight": "3 kg",
     "color": "dark_gray",
@@ -356,7 +573,12 @@
     "volume": "5 L",
     "longest_side": "70 cm",
     "looks_like": "briefcase",
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "good" },
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "any",
+      "balance": "good"
+    },
     "price": "300 USD",
     "price_postapoc": "8 USD",
     "melee_damage": { "bash": 8 }
@@ -365,7 +587,10 @@
     "type": "GENERIC",
     "id": "ego_blank",
     "category": "weapons",
-    "name": { "str": "blank EGO suitcase", "str_pl": "blank EGO suitcases" },
+    "name": {
+      "str": "blank EGO suitcase",
+      "str_pl": "blank EGO suitcases"
+    },
     "description": "Suitcase for transporting EGO. That one without marking. You even not sure if this realy an EGO",
     "weight": "3 kg",
     "color": "dark_gray",
@@ -376,7 +601,12 @@
     "volume": "5 L",
     "longest_side": "70 cm",
     "looks_like": "briefcase",
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "good" },
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "any",
+      "balance": "good"
+    },
     "price": "300 USD",
     "price_postapoc": "8 USD",
     "melee_damage": { "bash": 8 }
@@ -385,7 +615,10 @@
     "type": "GENERIC",
     "id": "ego_zayin",
     "category": "weapons",
-    "name": { "str": "ZAYIN EGO suitcase", "str_pl": "ZAYIN EGO suitcases" },
+    "name": {
+      "str": "ZAYIN EGO suitcase",
+      "str_pl": "ZAYIN EGO suitcases"
+    },
     "description": "Suitcase for transporting EGO.",
     "weight": "3 kg",
     "color": "dark_gray",
@@ -396,7 +629,12 @@
     "volume": "5 L",
     "longest_side": "70 cm",
     "looks_like": "briefcase",
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "good" },
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "any",
+      "balance": "good"
+    },
     "price": "300 USD",
     "price_postapoc": "10 USD",
     "melee_damage": { "bash": 8 }
@@ -405,7 +643,10 @@
     "type": "GENERIC",
     "id": "ego_teth",
     "category": "weapons",
-    "name": { "str": "TETH EGO suitcase", "str_pl": "TETH EGO suitcases" },
+    "name": {
+      "str": "TETH EGO suitcase",
+      "str_pl": "TETH EGO suitcases"
+    },
     "description": "Suitcase for transporting EGO.",
     "weight": "3 kg",
     "color": "dark_gray",
@@ -416,7 +657,12 @@
     "volume": "5 L",
     "longest_side": "70 cm",
     "looks_like": "briefcase",
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "good" },
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "any",
+      "balance": "good"
+    },
     "price": "300 USD",
     "price_postapoc": "40 USD",
     "melee_damage": { "bash": 8 }
@@ -425,7 +671,10 @@
     "type": "GENERIC",
     "id": "ego_he",
     "category": "weapons",
-    "name": { "str": "HE EGO suitcase", "str_pl": "HE EGO suitcases" },
+    "name": {
+      "str": "HE EGO suitcase",
+      "str_pl": "HE EGO suitcases"
+    },
     "description": "Suitcase for transporting EGO.",
     "weight": "3 kg",
     "color": "dark_gray",
@@ -436,7 +685,12 @@
     "volume": "5 L",
     "longest_side": "70 cm",
     "looks_like": "briefcase",
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "good" },
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "any",
+      "balance": "good"
+    },
     "price": "300 USD",
     "price_postapoc": "160 USD",
     "melee_damage": { "bash": 8 }
@@ -445,7 +699,10 @@
     "type": "GENERIC",
     "id": "ego_waw",
     "category": "weapons",
-    "name": { "str": "WAW EGO suitcase", "str_pl": "WAW EGO suitcases" },
+    "name": {
+      "str": "WAW EGO suitcase",
+      "str_pl": "WAW EGO suitcases"
+    },
     "description": "Suitcase for transporting EGO.",
     "weight": "3 kg",
     "color": "dark_gray",
@@ -456,7 +713,12 @@
     "volume": "5 L",
     "longest_side": "70 cm",
     "looks_like": "briefcase",
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "good" },
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "any",
+      "balance": "good"
+    },
     "price": "300 USD",
     "price_postapoc": "640 USD",
     "melee_damage": { "bash": 8 }
@@ -465,7 +727,10 @@
     "type": "GENERIC",
     "id": "ego_aleph",
     "category": "weapons",
-    "name": { "str": "ALEPH EGO suitcase", "str_pl": "ALEPH EGO suitcases" },
+    "name": {
+      "str": "ALEPH EGO suitcase",
+      "str_pl": "ALEPH EGO suitcases"
+    },
     "description": "Suitcase for transporting EGO. Goddamn, how do you get this?",
     "weight": "3 kg",
     "color": "dark_gray",
@@ -476,7 +741,12 @@
     "volume": "5 L",
     "longest_side": "70 cm",
     "looks_like": "briefcase",
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "good" },
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "any",
+      "balance": "good"
+    },
     "price": "300 USD",
     "price_postapoc": "1280 USD",
     "melee_damage": { "bash": 8 }
@@ -498,9 +768,341 @@
     "repairs_with": [ "pm_steel_item" ],
     "flags": [ "ALWAYS_TWOHAND", "DURABLE_MELEE", "SHEATH_SWORD", "REACH_ATTACK", "MESSY", "NONCONDUCTIVE", "POLEARM", "WHIP" ],
     "techniques": [ "WBLOCK_2", "WIDE", "BRUTAL", "SWEEP", "RAPID" ],
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "good" },
-    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -4 ] ],
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "line",
+      "balance": "good"
+    },
+    "qualities": [
+      [ "CUT", 1 ],
+      [ "BUTCHER", -4 ]
+    ],
     "weapon_category": [ "GREAT_SWORDS" ],
-    "melee_damage": { "bash": 44, "cut": 28 }
+    "melee_damage": {
+      "bash": 44,
+      "cut": 28
+    }
+  },
+  {
+    "type": "GENERIC",
+    "id": "w_l2_mace",
+    "name": { "str": "L2 cleanup agent shock baton" },
+    "description": "A one handed shock baton made of some black polymer. All of the power settings would be lethal to a human, unlike a normal stun baton. \n\nIt's branded in the markings of W Corp.",
+    "weight": "1300 g",
+    "color": "dark_gray",
+    "symbol": "/",
+    "looks_like": "PR24-extended",
+    "material": [ "b_polymer" ],
+    "repairs_with": [ "b_polymer_item" ],
+    "techniques": [ "WBLOCK_1", "SWEEP", "PRECISE" ],
+    "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "BELT_CLIP" ],
+    "weapon_category": [ "MACES" ],
+    "volume": "1350 ml",
+    "longest_side": "80 cm",
+    "to_hit": {
+      "grip": "weapon",
+      "length": "short",
+      "surface": "any",
+      "balance": "neutral"
+    },
+    "price": "1000 USD",
+    "price_postapoc": "210 USD",
+    "qualities": [ [ "HAMMER", 1 ] ],
+    "category": "weapons",
+    "melee_damage": { "bash": 37 }
+  },
+  {
+    "type": "GENERIC",
+    "id": "w_l2_hatchet",
+    "symbol": ";",
+    "looks_like": "hatchet",
+    "color": "light_gray",
+    "name": {
+      "str": "L2 cleanup agent hatchet"
+    },
+    "description": "A one-handed hatchet with a large blade head. The blade edge has a blue tint, and it appears like you might be able to turn it on. \n\nIt's branded in the markings of W Corp.",
+    "category": "tools",
+    "price": "1000 USD",
+    "price_postapoc": "210 USD",
+    "material": [
+      "pm_steel",
+      "b_polymer"
+    ],
+    "repairs_with": [ "pm_steel_item" ],
+    "techniques": [
+      "WBLOCK_1",
+      "SWEEP"
+    ],
+    "weight": "907 g",
+    "volume": "1 L",
+    "longest_side": "38 cm",
+    "to_hit": {
+      "grip": "weapon",
+      "length": "short",
+      "surface": "line",
+      "balance": "neutral"
+    },
+    "flags": [
+      "DURABLE_MELEE",
+      "BELT_CLIP",
+      "CONDUCTIVE",
+      "SHEATH_AXE"
+    ],
+    "weapon_category": [
+      "HAND_AXES"
+    ],
+    "qualities": [
+      [
+        "AXE",
+        2
+      ],
+      [
+        "CUT",
+        1
+      ],
+      [
+        "HAMMER",
+        2
+      ],
+      [
+        "HAMMER_FINE",
+        1
+      ],
+      [
+        "BUTCHER",
+        16
+      ]
+    ],
+    "melee_damage": {
+      "bash": 10,
+      "cut": 30
+    }
+  },
+  {
+    "id": "w_l2_polearm",
+    "type": "GENERIC",
+    "symbol": "/",
+    "color": "light_gray",
+    "name": {
+      "str": "w_polearm"
+    },
+    "description": "A sturdy polearm with a blue tinted blade edge. It resembles a glaive somewhat. You think you might be able to turn it on. \n\nIt's branded in the markings of W Corp.",
+    "price": "500 USD",
+    "material": [
+      "steel",
+      "wood"
+    ],
+    "qualities": [
+      [
+        "CUT",
+        1
+      ],
+      [
+        "BUTCHER",
+        -28
+      ]
+    ],
+    "flags": [
+      "DURABLE_MELEE",
+      "REACH_ATTACK",
+      "NONCONDUCTIVE",
+      "POLEARM",
+      "SHEATH_SPEAR",
+      "ALWAYS_TWOHAND"
+    ],
+    "weapon_category": [
+      "HOOKING_WEAPONRY",
+      "POLEARMS"
+    ],
+    "techniques": [
+      "WIDE",
+      "WBLOCK_1"
+    ],
+    "weight": "2100 g",
+    "volume": "2500 ml",
+    "longest_side": "180 cm",
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "line",
+      "balance": "neutral"
+    },
+    "price_postapoc": "80 USD",
+    "melee_damage": {
+      "bash": 10,
+      "cut": 40
+    }
+  },
+  {
+    "id": "w_l3_katana",
+    "type": "TOOL",
+    "category": "weapons",
+    "name": { "str_sp": "L3 cleanup agent katana" },
+    "description": "A long katana with a blue blade edge. There's a number of power settings on the handle, including one that reads 'DANGER, DISPLACES SPACE' in large red letters. \n\nIt's branded in the markings of W Corp.",
+    "weight": "1073 g",
+    "volume": "2 L",
+    "longest_side": "86 cm",
+    "symbol": "/",
+    "ascii_picture": "katana",
+    "color": "light_gray",
+    "looks_like": "katana",
+    "price": "800 USD",
+    "price_postapoc": "145 USD",
+    "material": [
+      {
+        "type": "b_polymer",
+        "portion": 1.1
+      },
+      {
+        "type": "c_steel",
+        "portion": 96
+      }
+    ],
+    "repairs_with": [ "c_steel_item" ],
+    "flags": [ "DURABLE_MELEE", "CONDUCTIVE", "SHEATH_SWORD" ],
+    "techniques": [ "RAPID", "WBLOCK_2", "PRECISE" ],
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "line",
+      "balance": "good"
+    },
+    "qualities": [
+      [ "CUT", 1 ],
+      [ "BUTCHER", 21 ]
+    ],
+    "weapon_category": [ "LONG_SWORDS" ],
+    "melee_damage": {
+      "bash": 5,
+      "cut": 51
+    }
+  },
+  {
+    "id": "w_l3_dual_blade",
+    "type": "TOOL",
+    "category": "weapons",
+    "name": { "str": "L3 cleanup agent dual blades" },
+    "description": "A pair of one handed swords with blue blade edges. Both have a number of power settings on their handle, including one that reads 'DANGER, DISPLACES SPACE' in large red letters.  \n\nIt's branded in the markings of W Corp.",
+    "weight": "2104 g",
+    "volume": "2750 ml",
+    "longest_side": "150 cm",
+    "symbol": "/",
+    "color": "light_gray",
+    "looks_like": "longsword",
+    "price": "1200 USD",
+    "price_postapoc": "215 USD",
+    "material": [
+      {
+        "type": "pm_leather",
+        "portion": 1.1
+      },
+      {
+        "type": "b_steel",
+        "portion": 112
+      }
+    ],
+    "repairs_with": [ "b_steel_item" ],
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ],
+    "techniques": [ "WBLOCK_1", "BRUTAL", "RAPID" ],
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "line",
+      "balance": "good"
+    },
+    "qualities": [
+      [ "CUT", 1 ],
+      [ "BUTCHER", 6 ]
+    ],
+    "weapon_category": [ "MEDIUM_SWORDS" ],
+    "melee_damage": {
+      "bash": 11,
+      "cut": 35
+    }
+  },
+  {
+    "id": "w_l3_short_blade",
+    "type": "TOOL",
+    "category": "weapons",
+    "name": { "str": "L3 cleanup agent short blade" },
+    "description": "A short one handed blade with a blue blade edge, it's about the size of a small machete overall. There's a number of power settings on the handle, including one that reads 'DANGER, DISPLACES SPACE' in large red letters. \n\nIt's branded in the markings of W Corp. ",
+    "weight": "750 g",
+    "volume": "1750 ml",
+    "longest_side": "50 cm",
+    "price": "120 USD",
+    "price_postapoc": "30 USD",
+    "to_hit": {
+      "grip": "weapon",
+      "length": "short",
+      "surface": "line",
+      "balance": "good"
+    },
+    "material": [
+      "bronze"
+    ],
+    "symbol": "/",
+    "color": "yellow",
+    "techniques": [
+      "WBLOCK_2",
+      "DEF_DISARM"
+    ],
+    "qualities": [
+      [
+        "CUT",
+        1
+      ],
+      [
+        "BUTCHER",
+        8
+      ]
+    ],
+    "flags": [
+      "DURABLE_MELEE",
+      "SHEATH_SWORD"
+    ],
+    "weapon_category": [
+      "SHORT_SWORDS"
+    ],
+    "melee_damage": {
+      "bash": 9,
+      "cut": 35
+    }
+  },
+  {
+    "type": "ARMOR",
+    "id": "w_l3_gauntlet",
+    "symbol": "3",
+    "color": "light_gray",
+    "name": { "str": "L3 cleanup agent captain's gauntlets" },
+    "looks_like": "chain",
+    "description": "A pait of large gauntlets made for punching. A tablet is attached to the bottom of one of the gauntlets, displaying information on your current dimension and allowing you to select various power settings.\n\nIt's branded in the markings of W Corp.",
+    "material": [ "b_steel" ],
+    "repairs_with": [ "b_steel_item" ],
+    "volume": "390 ml",
+    "weight": "340 g",
+    "price_postapoc": "2 USD",
+    "to_hit": {
+      "grip": "weapon",
+      "length": "hand",
+      "surface": "any",
+      "balance": "neutral"
+    },
+    "qualities": [ [ "HAMMER", 1 ] ],
+    "flags": [ "DURABLE_MELEE", "CONDUCTIVE" ],
+    "techniques": [ "BRUTAL", "WBLOCK_2" ],
+    "material_thickness": 2,
+    "armor": [
+      {
+        "encumbrance": 9,
+        "coverage": 55,
+        "covers": [ "hand_l", "hand_r", "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_lower_l", "arm_lower_r", "hand_back_l", "hand_back_r", "hand_wrist_l", "hand_wrist_r", "hand_fingers_l", "hand_fingers_r", "hand_palm_l", "hand_palm_r" ]
+      }
+    ],
+    "melee_damage": {
+      "bash": 8,
+      "stab": 3
+    }
   }
 ]


### PR DESCRIPTION
Added:
- W Corp weapons for L2 and L3 cleanup agents
- W Corp armour for L2 and L3 cleanup agents
- W Corp employee clothes and cap

Notes:
VS really wanted to indent the closed brackets for some items, which is why some unrelated lines where expanded. This shouldn't have an impact of anything, but I can go through and set them back to how they where if it's a problem. Look for big blocks of green for my changes.

Currently W Corp gear is using temporary stats, sprites and skills. I was asked to put them in the game in that state so development would be easier later on. 