### PR TITLE
add W corp equipment (fixed)

### DIFF
--- a/Items/armor.json
+++ b/Items/armor.json
@@ -1075,5 +1075,421 @@
     "environmental_protection": 1,
     "material_thickness": 1,
     "flags": [ "VARSIZE", "POCKETS", "OUTER", "STURDY"]
+  },
+  {
+    "id": "w_shirt",
+    "type": "ARMOR",
+    "name": { "str": "W Corp shirt" },
+    "description": "A dark formal shirt worn by employees of W Corp.",
+    "copy-from": "dress_shirt",
+    "price_postapoc": "10USD",
+    "looks_like": "pm_shirt_yel",
+    "material": [ "pm_cotton" ],
+    "repairs_with": [ "pm_cotton_item" ]
+  },
+  {
+    "id": "w_trousers",
+    "type": "ARMOR",
+    "name": { "str_sp": "W Corp trousers" },
+    "description": "A pair of dark blue trousers worn by employees of W Corp.",
+    "weight": "421 g",
+    "volume": "2 L",
+    "price": "12 USD",
+    "price_postapoc": "7 USD",
+    "to_hit": 1,
+    "material": [ "pm_cotton" ],
+    "repairs_with": [ "pm_cotton_item" ],
+    "symbol": "[",
+    "looks_like": "pants",
+    "color": "black",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "750 ml",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "11 cm",
+        "moves": 90
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "750 ml",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "11 cm",
+        "moves": 90
+      }
+    ],
+    "warmth": 8,
+    "material_thickness": 0.2,
+    "flags": [ "VARSIZE", "POCKETS", "FANCY" ],
+    "armor": [
+      {
+        "encumbrance": [ 3, 5 ],
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r" ]
+      }
+    ]
+  },
+  {
+    "id": "w_cap",
+    "type": "ARMOR",
+    "name": {
+      "str": "W Corp cap"
+    },
+    "description": "A black cap with the logo of W corp embroidered on the front.",
+    "weight": "92 g",
+    "volume": "500 ml",
+    "price": "15 USD",
+    "price_postapoc": "80 cent",
+    "material": [
+      "cotton"
+    ],
+    "symbol": "[",
+    "looks_like": "hat_ball",
+    "color": "dark_gray",
+    "warmth": 5,
+    "material_thickness": 0.3,
+    "environmental_protection": 1,
+    "flags": [
+      "VARSIZE",
+      "SUN_GLASSES"
+    ],
+    "armor": [
+      {
+        "encumbrance_modifiers": [
+          "NONE"
+        ],
+        "coverage": 100,
+        "covers": [
+          "head"
+        ],
+        "specifically_covers": [
+          "head_crown",
+          "head_forehead"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "w_l2_chestpiece",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "L2 cleanup agent chestpiece" },
+    "description": "A sturdy chestpiece worn by junior W Corp cleanup agents. Most agents will only wear this once before they quit or suffer an unfortunate workplace accident, and it seems you're the latest in that line. Designed to prioritise mobility and protect you from electric shocks.",
+    "weight": "3260 g",
+    "volume": "5 L",
+    "price": "350 USD",
+    "price_postapoc": "140 USD",
+    "to_hit": -3,
+    "material": [ "b_polymer", "l_cotton" ],
+    "repairs_with": [ "b_polymer_item" ],
+    "symbol": "[",
+    "looks_like": "vest_leather",
+    "color": "light_gray",
+    "warmth": 15,
+    "material_thickness": 4,
+    "flags": [ "STURDY", "ELECTRIC_IMMUNE" ],
+    "armor": [
+      {
+        "material": [
+          {
+            "type": "l_cotton",
+            "covered_by_mat": 100,
+            "thickness": 0.5
+          },
+          {
+            "type": "b_polymer",
+            "covered_by_mat": 95,
+            "thickness": 3.3,
+            "ignore_sheet_thickness": true
+          }
+        ],
+        "encumbrance": 3,
+        "coverage": 94,
+        "cover_vitals": 70,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_upper" ]
+      },
+      {
+        "material": [
+          {
+            "type": "l_cotton",
+            "covered_by_mat": 100,
+            "thickness": 0.5
+          },
+          {
+            "type": "b_polymer",
+            "covered_by_mat": 95,
+            "thickness": 3.3,
+            "ignore_sheet_thickness": true
+          }
+        ],
+        "encumbrance": 0,
+        "coverage": 85,
+        "cover_vitals": 60,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_lower" ]
+      }
+    ],
+    "melee_damage": { "bash": 6 }
+  },
+  {
+    "id": "w_l3_chestpiece",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "L3 cleanup agent chestpiece" },
+    "description": "A sturdy chestpiece worn by senior W Corp cleanup agents. You hear a small crackling noise coming from within the armor, and the chestpiece itself is warm to the touch. Either way, it appears safe to wear, and doesn't impede your movements much. ",
+    "weight": "3260 g",
+    "volume": "5 L",
+    "price": "350 USD",
+    "price_postapoc": "140 USD",
+    "to_hit": -3,
+    "material": [ "b_polymer", "l_cotton" ],
+    "repairs_with": [ "b_polymer_item" ],
+    "symbol": "[",
+    "looks_like": "vest_leather",
+    "color": "light_gray",
+    "warmth": 15,
+    "material_thickness": 4,
+    "flags": [ "STURDY", "ELECTRIC_IMMUNE" ],
+    "armor": [
+      {
+        "material": [
+          {
+            "type": "l_cotton",
+            "covered_by_mat": 100,
+            "thickness": 0.5
+          },
+          {
+            "type": "b_polymer",
+            "covered_by_mat": 95,
+            "thickness": 3.3,
+            "ignore_sheet_thickness": true
+          }
+        ],
+        "encumbrance": 3,
+        "coverage": 94,
+        "cover_vitals": 70,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_upper" ]
+      },
+      {
+        "material": [
+          {
+            "type": "l_cotton",
+            "covered_by_mat": 100,
+            "thickness": 0.5
+          },
+          {
+            "type": "b_polymer",
+            "covered_by_mat": 95,
+            "thickness": 3.3,
+            "ignore_sheet_thickness": true
+          }
+        ],
+        "encumbrance": 0,
+        "coverage": 85,
+        "cover_vitals": 60,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_lower" ]
+      }
+    ],
+    "melee_damage": { "bash": 6 }
+  },
+  {
+    "id": "w_bracers",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": {
+      "str": "Cleanup agent bracers",
+      "str_pl": "Pairs of cleanup agent bracers"
+    },
+    "description": "A pair of metalic bracers, used to protect your arms from harm. They're lighter than you expected.",
+    "weight": "1500 g",
+    "volume": "1850 ml",
+    "price_postapoc": "40 USD",
+    "to_hit": -1,
+    "material": [ "pm_steel" ],
+    "repairs_with": [ "pm_steel_item" ],
+    "symbol": "[",
+    "looks_like": "armguard_hard",
+    "color": "dark_gray",
+    "material_thickness": 3.5,
+    "sided": true,
+    "flags": [ "WATER_FRIENDLY", "BELTED", "BLOCK_WHILE_WORN", "STURDY" ],
+    "armor": [
+      {
+        "covers": [ "arm_l", "arm_r" ],
+        "encumbrance": 3,
+        "coverage": 90,
+        "cover_melee": 90,
+        "cover_ranged": 95,
+        "cover_vitals": 90,
+        "specifically_covers": [ "arm_lower_l", "arm_lower_r" ]
+      }
+    ]
+  },
+  {
+    "id": "w_gloves",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": {
+      "str": "Pair of cleanup agent gloves",
+      "str_pl": "Pairs of cleanup agent gloves"
+    },
+    "description": "A pair of cut resistant gloves worn by W Corp cleanup agents.'",
+    "weight": "220 g",
+    "volume": "500 ml",
+    "price": "52 USD",
+    "price_postapoc": "15 USD",
+    "material": [
+      "kevlar",
+      "leather"
+    ],
+    "symbol": "[",
+    "looks_like": "fire_gauntlets",
+    "color": "dark_gray",
+    "warmth": 20,
+    "material_thickness": 2,
+    "environmental_protection": 4,
+    "flags": [
+      "VARSIZE",
+      "STURDY"
+    ],
+    "armor": [
+      {
+        "encumbrance": 6,
+        "coverage": 100,
+        "covers": [
+          "hand_l",
+          "hand_r"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "w_boots",
+    "type": "ARMOR",
+    "name": {
+      "str": "Pair of cleanup agent boots",
+      "str_pl": "Pairs of cleanup agent boots"
+    },
+    "description": "A pair of surprisingly tough leather boots, designed to be easy to clean and wash in tandem with proprietary W Corp detergents.",
+    "weight": "1360 g",
+    "volume": "2645 ml",
+    "price": "100 USD",
+    "price_postapoc": "20 USD",
+    "to_hit": -1,
+    "symbol": "[",
+    "repairs_with": [ "pm_leather_item" ],
+    "looks_like": "dress_shoes",
+    "color": "dark_gray",
+    "warmth": 16,
+    "environmental_protection": 3,
+    "flags": [ "VARSIZE", "WATERPROOF" ],
+    "armor": [
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [
+          "foot_toes_r",
+          "foot_toes_l",
+          "foot_ankle_r",
+          "foot_ankle_l",
+          "foot_heel_r",
+          "foot_heel_l",
+          "foot_arch_r",
+          "foot_arch_l"
+        ],
+        "material": [
+          {
+            "type": "pm_leather",
+            "covered_by_mat": 100,
+            "thickness": 2.5
+          }
+        ],
+        "encumbrance": 12,
+        "coverage": 100
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
+        "material": [
+          {
+            "type": "pm_leather",
+            "covered_by_mat": 100,
+            "thickness": 0.1
+          },
+          {
+            "type": "rubber",
+            "covered_by_mat": 100,
+            "thickness": 6.0
+          }
+        ],
+        "coverage": 100
+      }
+    ],
+    "melee_damage": { "bash": 2 }
+  },
+  {
+    "id": "w_advanced_boots",
+    "type": "ARMOR",
+    "name": {
+      "str": "Pair of advanced cleanup agent boots",
+      "str_pl": "Pairs of advanced cleanup agent boots"
+    },
+    "description": "A pair of tough metallic greaves that lead up to the ankle. When powered, they grant improve mobility and secure the user to the ground, even in areas of low gravity or poor dimensional stability. Worn exclusively by high ranking W Corp cleanup agents.",
+    "weight": "1360 g",
+    "volume": "2645 ml",
+    "price": "100 USD",
+    "price_postapoc": "20 USD",
+    "to_hit": -1,
+    "symbol": "[",
+    "repairs_with": [ "pm_steel" ],
+    "looks_like": "dress_shoes",
+    "color": "dark_gray",
+    "warmth": 16,
+    "environmental_protection": 3,
+    "flags": [ "VARSIZE", "WATERPROOF" ],
+    "armor": [
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [
+          "foot_toes_r",
+          "foot_toes_l",
+          "foot_ankle_r",
+          "foot_ankle_l",
+          "foot_heel_r",
+          "foot_heel_l",
+          "foot_arch_r",
+          "foot_arch_l"
+        ],
+        "material": [
+          {
+            "type": "pm_leather",
+            "covered_by_mat": 100,
+            "thickness": 2.5
+          }
+        ],
+        "encumbrance": 12,
+        "coverage": 100
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
+        "material": [
+          {
+            "type": "pm_steel",
+            "covered_by_mat": 100,
+            "thickness": 0.1
+          },
+          {
+            "type": "rubber",
+            "covered_by_mat": 100,
+            "thickness": 6.0
+          }
+        ],
+        "coverage": 100
+      }
+    ],
+    "melee_damage": { "bash": 2 }
   }
 ]

--- a/Items/melee.json
+++ b/Items/melee.json
@@ -502,5 +502,326 @@
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -4 ] ],
     "weapon_category": [ "GREAT_SWORDS" ],
     "melee_damage": { "bash": 44, "cut": 28 }
+  },
+  {
+    "type": "GENERIC",
+    "id": "w_l2_mace",
+    "name": { "str": "L2 cleanup agent shock baton" },
+    "description": "A one handed shock baton made of some black polymer. All of the power settings would be lethal to a human, unlike a normal stun baton. \n\nIt's branded in the markings of W Corp.",
+    "weight": "1300 g",
+    "color": "dark_gray",
+    "symbol": "/",
+    "looks_like": "PR24-extended",
+    "material": [ "b_polymer" ],
+    "repairs_with": [ "b_polymer_item" ],
+    "techniques": [ "WBLOCK_1", "SWEEP", "PRECISE" ],
+    "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "BELT_CLIP" ],
+    "weapon_category": [ "MACES" ],
+    "volume": "1350 ml",
+    "longest_side": "80 cm",
+    "to_hit": {
+      "grip": "weapon",
+      "length": "short",
+      "surface": "any",
+      "balance": "neutral"
+    },
+    "price": "1000 USD",
+    "price_postapoc": "210 USD",
+    "qualities": [ [ "HAMMER", 1 ] ],
+    "category": "weapons",
+    "melee_damage": { "bash": 37 }
+  },
+  {
+    "type": "GENERIC",
+    "id": "w_l2_hatchet",
+    "symbol": ";",
+    "looks_like": "hatchet",
+    "color": "light_gray",
+    "name": {
+      "str": "L2 cleanup agent hatchet"
+    },
+    "description": "A one-handed hatchet with a large blade head. The blade edge has a blue tint, and it appears like you might be able to turn it on. \n\nIt's branded in the markings of W Corp.",
+    "category": "tools",
+    "price": "1000 USD",
+    "price_postapoc": "210 USD",
+    "material": [
+      "pm_steel",
+      "b_polymer"
+    ],
+    "repairs_with": [ "pm_steel_item" ],
+    "techniques": [
+      "WBLOCK_1",
+      "SWEEP"
+    ],
+    "weight": "907 g",
+    "volume": "1 L",
+    "longest_side": "38 cm",
+    "to_hit": {
+      "grip": "weapon",
+      "length": "short",
+      "surface": "line",
+      "balance": "neutral"
+    },
+    "flags": [
+      "DURABLE_MELEE",
+      "BELT_CLIP",
+      "CONDUCTIVE",
+      "SHEATH_AXE"
+    ],
+    "weapon_category": [
+      "HAND_AXES"
+    ],
+    "qualities": [
+      [
+        "AXE",
+        2
+      ],
+      [
+        "CUT",
+        1
+      ],
+      [
+        "HAMMER",
+        2
+      ],
+      [
+        "HAMMER_FINE",
+        1
+      ],
+      [
+        "BUTCHER",
+        16
+      ]
+    ],
+    "melee_damage": {
+      "bash": 10,
+      "cut": 30
+    }
+  },
+  {
+    "id": "w_l2_polearm",
+    "type": "GENERIC",
+    "symbol": "/",
+    "color": "light_gray",
+    "name": {
+      "str": "w_polearm"
+    },
+    "description": "A sturdy polearm with a blue tinted blade edge. It resembles a glaive somewhat. You think you might be able to turn it on. \n\nIt's branded in the markings of W Corp.",
+    "price": "500 USD",
+    "material": [
+      "steel",
+      "wood"
+    ],
+    "qualities": [
+      [
+        "CUT",
+        1
+      ],
+      [
+        "BUTCHER",
+        -28
+      ]
+    ],
+    "flags": [
+      "DURABLE_MELEE",
+      "REACH_ATTACK",
+      "NONCONDUCTIVE",
+      "POLEARM",
+      "SHEATH_SPEAR",
+      "ALWAYS_TWOHAND"
+    ],
+    "weapon_category": [
+      "HOOKING_WEAPONRY",
+      "POLEARMS"
+    ],
+    "techniques": [
+      "WIDE",
+      "WBLOCK_1"
+    ],
+    "weight": "2100 g",
+    "volume": "2500 ml",
+    "longest_side": "180 cm",
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "line",
+      "balance": "neutral"
+    },
+    "price_postapoc": "80 USD",
+    "melee_damage": {
+      "bash": 10,
+      "cut": 40
+    }
+  },
+  {
+    "id": "w_l3_katana",
+    "type": "TOOL",
+    "category": "weapons",
+    "name": { "str_sp": "L3 cleanup agent katana" },
+    "description": "A long katana with a blue blade edge. There's a number of power settings on the handle, including one that reads 'DANGER, DISPLACES SPACE' in large red letters. \n\nIt's branded in the markings of W Corp.",
+    "weight": "1073 g",
+    "volume": "2 L",
+    "longest_side": "86 cm",
+    "symbol": "/",
+    "ascii_picture": "katana",
+    "color": "light_gray",
+    "looks_like": "katana",
+    "price": "800 USD",
+    "price_postapoc": "145 USD",
+    "material": [
+      {
+        "type": "b_polymer",
+        "portion": 1.1
+      },
+      {
+        "type": "c_steel",
+        "portion": 96
+      }
+    ],
+    "repairs_with": [ "c_steel_item" ],
+    "flags": [ "DURABLE_MELEE", "CONDUCTIVE", "SHEATH_SWORD" ],
+    "techniques": [ "RAPID", "WBLOCK_2", "PRECISE" ],
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "line",
+      "balance": "good"
+    },
+    "qualities": [
+      [ "CUT", 1 ],
+      [ "BUTCHER", 21 ]
+    ],
+    "weapon_category": [ "LONG_SWORDS" ],
+    "melee_damage": {
+      "bash": 5,
+      "cut": 51
+    }
+  },
+  {
+    "id": "w_l3_dual_blade",
+    "type": "TOOL",
+    "category": "weapons",
+    "name": { "str": "L3 cleanup agent dual blades" },
+    "description": "A pair of one handed swords with blue blade edges. Both have a number of power settings on their handle, including one that reads 'DANGER, DISPLACES SPACE' in large red letters.  \n\nIt's branded in the markings of W Corp.",
+    "weight": "2104 g",
+    "volume": "2750 ml",
+    "longest_side": "150 cm",
+    "symbol": "/",
+    "color": "light_gray",
+    "looks_like": "longsword",
+    "price": "1200 USD",
+    "price_postapoc": "215 USD",
+    "material": [
+      {
+        "type": "pm_leather",
+        "portion": 1.1
+      },
+      {
+        "type": "b_steel",
+        "portion": 112
+      }
+    ],
+    "repairs_with": [ "b_steel_item" ],
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ],
+    "techniques": [ "WBLOCK_1", "BRUTAL", "RAPID" ],
+    "to_hit": {
+      "grip": "weapon",
+      "length": "long",
+      "surface": "line",
+      "balance": "good"
+    },
+    "qualities": [
+      [ "CUT", 1 ],
+      [ "BUTCHER", 6 ]
+    ],
+    "weapon_category": [ "MEDIUM_SWORDS" ],
+    "melee_damage": {
+      "bash": 11,
+      "cut": 35
+    }
+  },
+  {
+    "id": "w_l3_short_blade",
+    "type": "TOOL",
+    "category": "weapons",
+    "name": { "str": "L3 cleanup agent short blade" },
+    "description": "A short one handed blade with a blue blade edge, it's about the size of a small machete overall. There's a number of power settings on the handle, including one that reads 'DANGER, DISPLACES SPACE' in large red letters. \n\nIt's branded in the markings of W Corp. ",
+    "weight": "750 g",
+    "volume": "1750 ml",
+    "longest_side": "50 cm",
+    "price": "120 USD",
+    "price_postapoc": "30 USD",
+    "to_hit": {
+      "grip": "weapon",
+      "length": "short",
+      "surface": "line",
+      "balance": "good"
+    },
+    "material": [
+      "bronze"
+    ],
+    "symbol": "/",
+    "color": "yellow",
+    "techniques": [
+      "WBLOCK_2",
+      "DEF_DISARM"
+    ],
+    "qualities": [
+      [
+        "CUT",
+        1
+      ],
+      [
+        "BUTCHER",
+        8
+      ]
+    ],
+    "flags": [
+      "DURABLE_MELEE",
+      "SHEATH_SWORD"
+    ],
+    "weapon_category": [
+      "SHORT_SWORDS"
+    ],
+    "melee_damage": {
+      "bash": 9,
+      "cut": 35
+    }
+  },
+  {
+    "type": "ARMOR",
+    "id": "w_l3_gauntlet",
+    "symbol": "3",
+    "color": "light_gray",
+    "name": { "str": "L3 cleanup agent captain's gauntlets" },
+    "looks_like": "chain",
+    "description": "A pait of large gauntlets made for punching. A tablet is attached to the bottom of one of the gauntlets, displaying information on your current dimension and allowing you to select various power settings.\n\nIt's branded in the markings of W Corp.",
+    "material": [ "b_steel" ],
+    "repairs_with": [ "b_steel_item" ],
+    "volume": "390 ml",
+    "weight": "340 g",
+    "price_postapoc": "2 USD",
+    "to_hit": {
+      "grip": "weapon",
+      "length": "hand",
+      "surface": "any",
+      "balance": "neutral"
+    },
+    "qualities": [ [ "HAMMER", 1 ] ],
+    "flags": [ "DURABLE_MELEE", "CONDUCTIVE" ],
+    "techniques": [ "BRUTAL", "WBLOCK_2" ],
+    "material_thickness": 2,
+    "armor": [
+      {
+        "encumbrance": 9,
+        "coverage": 55,
+        "covers": [ "hand_l", "hand_r", "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_lower_l", "arm_lower_r", "hand_back_l", "hand_back_r", "hand_wrist_l", "hand_wrist_r", "hand_fingers_l", "hand_fingers_r", "hand_palm_l", "hand_palm_r" ]
+      }
+    ],
+    "melee_damage": {
+      "bash": 8,
+      "stab": 3
+    }
   }
 ]


### PR DESCRIPTION
Added:
- W Corp weapons for L2 and L3 cleanup agents
- W Corp armour for L2 and L3 cleanup agents
- W Corp employee clothes and cap

Notes:
The previous PR changed the formatting of some files on accident, this PR does not.

Currently W Corp gear is using temporary stats, sprites and skills. I was asked to put them in the game in that state so development would be easier later on. 