### PR TITLE
Fixed "invalid or misplaced field" errors for internet items

### DIFF
--- a/Items/internet/internet_access.json
+++ b/Items/internet/internet_access.json
@@ -54,11 +54,7 @@
       },
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" },
       {
-        "msg": "You open the browser app.",
         "menu_text": "Browse the web",
-        "active": true,
-        "need_charges": 1,
-        "need_charges_msg": "The smartphone's charge is too low.",
         "type": "effect_on_conditions",
         "effect_on_conditions": [ "EOC_internet_access" ]
       }
@@ -120,11 +116,7 @@
       },
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" },
       {
-        "msg": "You open the browser app.",
         "menu_text": "Browse the web",
-        "active": true,
-        "need_charges": 1,
-        "need_charges_msg": "The smartphone's charge is too low.",
         "type": "effect_on_conditions",
         "effect_on_conditions": [ "EOC_internet_access" ]
       }
@@ -194,11 +186,7 @@
       },
       { "type": "link_up", "cable_length": 5, "charge_rate": "140 W" },
       {
-        "msg": "You open the browser app.",
         "menu_text": "Browse the web",
-        "active": true,
-        "need_charges": 1,
-        "need_charges_msg": "The laptop's batteries need more charge.",
         "type": "effect_on_conditions",
         "effect_on_conditions": [ "EOC_internet_access" ]
       }
@@ -250,11 +238,7 @@
       },
       { "type": "link_up", "cable_length": 5, "charge_rate": "140 W" },
       {
-        "msg": "You open the browser app.",
         "menu_text": "Browse the web",
-        "active": true,
-        "need_charges": 1,
-        "need_charges_msg": "The laptop's batteries need more charge.",
         "type": "effect_on_conditions",
         "effect_on_conditions": [ "EOC_internet_access" ]
       }


### PR DESCRIPTION
After a bit of testing, I found out that the JSON lines causing the errors were actually unnecessary.
Removing the offending lines and testing it later on current latest experimental (2025-03-04-0559) reveal that it works just as fine as before.