### PR TITLE
Trashcans and Cooldowns

### DIFF
--- a/Items/Item_group.json
+++ b/Items/Item_group.json
@@ -120,9 +120,15 @@
     }
   },
   {
-    "id": "trash",
+    "id": "SUS_trash_trashcan",
     "type": "item_group",
-    "copy-from": "trash",
+    "copy-from": "SUS_trash_trashcan",
+    "extend": { "items": [ { "item": "zweiflyer_item", "prob": 12 } ] }
+  },
+  {
+    "id": "SUS_trash_floor",
+    "type": "item_group",
+    "copy-from": "SUS_trash_floor",
     "extend": { "items": [ { "item": "zweiflyer_item", "prob": 12 } ] }
   },
   {

--- a/Maps/Mapgen/Zwei/Zwei_office.json
+++ b/Maps/Mapgen/Zwei/Zwei_office.json
@@ -78,7 +78,7 @@
         "n": { "item": "SUS_office_desk", "chance": 75 },
         "v": { "item": "SUS_office_filing_cabinet", "chance": 80 },
         "R": { "item": "office_supplies", "chance": 80, "repeat": [ 1, 2 ] },
-        "@": { "item": "trash", "chance": 60, "repeat": [ 1, 2 ] },
+        "@": { "item": "SUS_trash_trashcan", "chance": 60, "repeat": [ 1, 2 ] },
         "B": { "item": "novels", "chance": 80, "repeat": [ 4, 8 ] }
       }
 }

--- a/ScaryMonstersAndNiceSprites/Distortions.json
+++ b/ScaryMonstersAndNiceSprites/Distortions.json
@@ -22,7 +22,7 @@
     "melee_dice": 1,
     "melee_dice_sides": 6,
     "melee_damage": [ { "damage_type": "stab", "amount": 6 }, { "damage_type": "heat", "amount": 6 } ],
-    "special_attacks": [ { "type": "monster_attack", "attack_type": "melee", "id": "irae" } ],
+    "special_attacks": [ { "type": "monster_attack", "attack_type": "melee", "id": "irae", "cooldown": 5 } ],
     "dodge": 3,
     "weakpoint_sets": [ "wps_irae_body" ],
     "families": [ "prof_wp_distortions0", "prof_wp_distortions1", "prof_wp_pecca" ],
@@ -55,7 +55,7 @@
     "melee_dice": 1,
     "melee_dice_sides": 8,
     "melee_damage": [ { "damage_type": "bash", "amount": 12 } ],
-    "special_attacks": [ { "type": "monster_attack", "attack_type": "melee", "id": "luxuriae" } ],
+    "special_attacks": [ { "type": "monster_attack", "attack_type": "melee", "id": "luxuriae", "cooldown": 5 } ],
     "dodge": 1,
     "weakpoint_sets": [ "wps_luxiae_body" ],
     "families": [ "prof_wp_distortions0", "prof_wp_distortions1", "prof_wp_pecca" ],
@@ -94,7 +94,8 @@
         "type": "monster_attack",
         "attack_type": "melee",
         "id": "superbiae",
-        "self_effects_onhit": [ { "id": "accel", "duration": 10, "intensity": 10 } ]
+        "self_effects_onhit": [ { "id": "accel", "duration": 10, "intensity": 10 } ],
+        "cooldown": 5
       }
     ],
     "dodge": 4,
@@ -281,7 +282,7 @@
     "melee_dice": 1,
     "melee_dice_sides": 8,
     "melee_damage": [ { "damage_type": "bash", "amount": 12 } ],
-    "special_attacks": [ { "type": "monster_attack", "attack_type": "melee", "id": "luxuriae" } ],
+    "special_attacks": [ { "type": "monster_attack", "attack_type": "melee", "id": "luxuriae", "cooldown": 5 } ],
     "dodge": 1,
     "weakpoint_sets": [ "wps_luxiae_body" ],
     "families": [ "prof_wp_distortions0", "prof_wp_distortions1", "prof_wp_pecca" ],


### PR DESCRIPTION
A simple push request to refamiliarize myself with git

Changes:

1.) Previously, the zwei flyer was added to the item group "trash" before CDDA did the SUS overhaul. As such, I added the zwei flyer to be added to 2 trash itemgroups, "SUS_trash_trashcan" and "SUS_trash_floor". In testing, I spawned 100 instances of each itemgroup, and got this results . 
Out of 100 instances of "SUS_trash_floor" itemgroup, I found 12 zwei flyers. 
Out of 100 instances of "SUS_trash_trashcan" itemgroup, I found 37 zwei flyers.
I feel like this is a realistic enough representation of flyers in the garbage.

2.) Changed the "trash" itemgroup in the zwei office to "SUS_trash_trashcan", since I saw that the trash was meant to spawn in a trashcan.

3.) Added 5 turn cooldowns to each pecca that was lacking a cooldown field for whatever reason.

I tested this on 2025-06-19-0557, and no errors occured. Also tested this on latest experimental for the funsies (as of this post is 2025-06-28-0922) and no errors occured.

Gonna look at void dream next