### PR TITLE
Migrate deprecated revert_to to transform_into

### DIFF
--- a/Items/StigmaWorkshop/weapons.json
+++ b/Items/StigmaWorkshop/weapons.json
@@ -141,7 +141,7 @@
       }
     ],
     "power_draw": "1560 W",
-    "revert_to": "stigma_bat_u"
+    "transform_into": { "target": "stigma_bat_u" }
   },
   {
     "type": "technique",
@@ -330,7 +330,7 @@
       }
     ],
     "power_draw": "500 kW",
-    "revert_to": "stigma_shortsword_u"
+    "transform_into": { "target": "stigma_shortsword_u" }
   },
   {
     "id": "stigma_axe_u",
@@ -493,6 +493,6 @@
       }
     ],
     "power_draw": "600 kW",
-    "revert_to": "stigma_axe_u"
+    "transform_into": { "target": "stigma_axe_u" }
   }
 ]

--- a/Items/internet/internet_access.json
+++ b/Items/internet/internet_access.json
@@ -146,7 +146,7 @@
       }
     ],
     "power_draw": "1500 mW",
-    "revert_to": "smart_phone"
+    "transform_into": { "target": "smart_phone" }
   },
   {
     "type": "ITEM",
@@ -255,6 +255,6 @@
       }
     ],
     "power_draw": "1 W",
-    "revert_to": "laptop"
+    "transform_into": { "target": "laptop" }
   }
 ]


### PR DESCRIPTION
Per latest CDDA ITEM.md, revert_to is deprecated in favor of transform_into (they are mutually exclusive). Converts the five tool items that used the legacy field to the modern object form.

https://claude.ai/code/session_01SArFVhw4cNbc9t7aTpvGg9